### PR TITLE
Bearer Auth

### DIFF
--- a/packages/core/src/auth/scopes.ts
+++ b/packages/core/src/auth/scopes.ts
@@ -1,9 +1,37 @@
-export function hasAll(required: string[], given: string[]): boolean {
-  for (const s of required) if (!given.includes(s)) return false;
-  return true;
+// Initial coarse-grained scopes for CLI bearer tokens.
+// Keep small and explicit; no wildcards for v1.
+
+export const SCOPES = {
+  CORE_READ: "core:read",
+  CORE_WRITE: "core:write",
+  FILES_READ: "files:read",
+  FILES_WRITE: "files:write",
+  BUNDLES_READ: "bundles:read",
+  BUNDLES_WRITE: "bundles:write",
+  PLUGINS_READ: "plugins:read",
+  PLUGINS_MANAGE: "plugins:manage",
+  TRIGGERS_READ: "triggers:read",
+  TRIGGERS_WRITE: "triggers:write",
+  ACTIONS_READ: "actions:read",
+  ACTIONS_WRITE: "actions:write",
+  PIPELINES_READ: "pipelines:read",
+  PIPELINES_WRITE: "pipelines:write",
+  CAPABILITIES_READ: "capabilities:read",
+} as const;
+
+export type Scope = (typeof SCOPES)[keyof typeof SCOPES];
+
+// Simple helpers for scope evaluation
+export function hasAll(required: string[], granted: string[]): boolean {
+  if (!required || required.length === 0) return true;
+  if (!granted || granted.length === 0) return false;
+  const set = new Set(granted);
+  return required.every((s) => set.has(s));
 }
 
-export function hasAny(required: string[], given: string[]): boolean {
-  for (const s of required) if (given.includes(s)) return true;
-  return false;
+export function hasAny(required: string[], granted: string[]): boolean {
+  if (!required || required.length === 0) return true;
+  if (!granted || granted.length === 0) return false;
+  const set = new Set(granted);
+  return required.some((s) => set.has(s));
 }

--- a/packages/core/src/middleware/require-admin-or-api-token.test.ts
+++ b/packages/core/src/middleware/require-admin-or-api-token.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { HttpHandler, RequestLike, ResponseLike } from "../http/http-server.js";
+
+// Use the prisma mock via direct import (same instance as alias target)
+import { prisma } from "../test/prisma-mock.js";
+
+// Mock require-session used by requirePermission so cookie path works in tests
+vi.mock("./require-session.js", () => ({
+  requireSession: vi.fn(async () => ({ user: { id: "u-admin", role: "ADMIN", isActive: true } })),
+}));
+import { requireSession } from "./require-session.js";
+
+// Use real requirePermission and requireApiToken (which see prisma mock via alias)
+import { requireAdminOrApiToken } from "./require-admin-or-api-token.js";
+
+function makeResCapture() {
+  let statusCode = 0;
+  let jsonBody: any = undefined;
+  const res: ResponseLike = {
+    status(c: number) {
+      statusCode = c;
+      return this;
+    },
+    json(p: any) {
+      jsonBody = p;
+    },
+    header() {
+      return this;
+    },
+    redirect() {},
+  };
+  return {
+    res,
+    get status() {
+      return statusCode;
+    },
+    get body() {
+      return jsonBody;
+    },
+  };
+}
+
+describe("requireAdminOrApiToken", () => {
+  beforeEach(() => {
+    // reset prisma mocks
+    Object.values(prisma).forEach((model: any) => {
+      if (model && model.findUnique?.mockReset) model.findUnique.mockReset();
+      if (model && model.update?.mockReset) model.update.mockReset();
+    });
+    // reset requireSession mock implementation and calls
+    if ((requireSession as any).mockReset) (requireSession as any).mockReset();
+    if ((requireSession as any).mockClear) (requireSession as any).mockClear();
+    (requireSession as any).mockResolvedValue({
+      user: { id: "u-admin", role: "ADMIN", isActive: true },
+    });
+  });
+
+  it("allows bearer token with required scope", async () => {
+    const token = {
+      id: "t1",
+      scopes: ["core:read"],
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      user: { id: "u1", email: "u1@example.com", isActive: true },
+    } as any;
+    (prisma.apiToken.findUnique as any).mockResolvedValueOnce(token);
+    (prisma.apiToken.update as any).mockResolvedValueOnce({});
+
+    let called = false;
+    const handler: HttpHandler = async (_req, res) => {
+      called = true;
+      res.status(200).json({ ok: true });
+    };
+    const wrapped = requireAdminOrApiToken({
+      policySignature: "GET /plugins",
+      scopes: ["core:read"],
+    })(handler);
+
+    const req: RequestLike = {
+      headers: { authorization: "Bearer abc" },
+    };
+    const rc = makeResCapture();
+    await wrapped(req, rc.res);
+    expect(called).toBe(true);
+    expect(rc.status).toBe(200);
+    expect(rc.body).toEqual({ ok: true });
+  });
+
+  it("rejects bearer token missing required scope (403)", async () => {
+    const token = {
+      id: "t1",
+      scopes: ["core:read"],
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      user: { id: "u1", email: "u1@example.com", isActive: true },
+    } as any;
+    (prisma.apiToken.findUnique as any).mockResolvedValueOnce(token);
+    (prisma.apiToken.update as any).mockResolvedValueOnce({});
+
+    const handler: HttpHandler = async (_req, _res) => {
+      // should not run
+      throw new Error("handler should not be called");
+    };
+    const wrapped = requireAdminOrApiToken({
+      policySignature: "POST /plugins/install",
+      scopes: ["core:write"],
+    })(handler);
+
+    const req: RequestLike = { headers: { authorization: "Bearer abc" } };
+    const rc = makeResCapture();
+    let err: any = null;
+    try {
+      await wrapped(req, rc.res);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeTruthy();
+    expect((err as any).status).toBe(403);
+  });
+
+  it("rejects bearer token when revoked (401)", async () => {
+    const token = {
+      id: "t1",
+      scopes: ["core:read", "core:write"],
+      revokedAt: new Date(),
+      expiresAt: new Date(Date.now() + 3600_000),
+      user: { id: "u1", email: "u1@example.com", isActive: true },
+    } as any;
+    (prisma.apiToken.findUnique as any).mockResolvedValueOnce(token);
+
+    const handler: HttpHandler = async (_req, _res) => {
+      throw new Error("handler should not be called");
+    };
+    const wrapped = requireAdminOrApiToken({
+      policySignature: "GET /plugins",
+      scopes: ["core:read"],
+    })(handler);
+
+    const req: RequestLike = { headers: { authorization: "Bearer abc" } };
+    const rc = makeResCapture();
+    let err: any;
+    try {
+      await wrapped(req, rc.res);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeTruthy();
+    expect((err as any).status).toBe(401);
+  });
+
+  it("rejects bearer token when expired (401)", async () => {
+    const token = {
+      id: "t1",
+      scopes: ["core:read"],
+      revokedAt: null,
+      expiresAt: new Date(Date.now() - 1000),
+      user: { id: "u1", email: "u1@example.com", isActive: true },
+    } as any;
+    (prisma.apiToken.findUnique as any).mockResolvedValueOnce(token);
+
+    const handler: HttpHandler = async (_req, _res) => {
+      throw new Error("handler should not be called");
+    };
+    const wrapped = requireAdminOrApiToken({
+      policySignature: "GET /plugins",
+      scopes: ["core:read"],
+    })(handler);
+    const req: RequestLike = { headers: { authorization: "Bearer abc" } };
+    const rc = makeResCapture();
+    let err: any;
+    try {
+      await wrapped(req, rc.res);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeTruthy();
+    expect((err as any).status).toBe(401);
+  });
+
+  it("blocks executor via cookie on admin-only route (403)", async () => {
+    // Force cookie path by omitting Authorization header
+    (requireSession as any).mockResolvedValueOnce({
+      user: { id: "u-exec", role: "EXECUTOR", isActive: true },
+    });
+    const handler: HttpHandler = async (_req, _res) => {
+      throw new Error("handler should not be called");
+    };
+    const wrapped = requireAdminOrApiToken({
+      policySignature: "POST /plugins/install",
+      scopes: ["core:write"],
+    })(handler);
+    const req: RequestLike = { headers: {} } as any;
+    const rc = makeResCapture();
+    let err: any;
+    try {
+      await wrapped(req, rc.res);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeTruthy();
+    expect((err as any).status).toBe(403);
+  });
+
+  it("uses bearer path when Authorization present (no cookie needed)", async () => {
+    (prisma.apiToken.findUnique as any).mockResolvedValueOnce({
+      id: "t1",
+      scopes: ["core:read"],
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      user: { id: "u1", email: "u1@example.com", isActive: true },
+    } as any);
+    (prisma.apiToken.update as any).mockResolvedValueOnce({});
+    let called = false;
+    const handler: HttpHandler = async (_req, res) => {
+      called = true;
+      res.status(200).json({ ok: true });
+    };
+    const wrapped = requireAdminOrApiToken({
+      policySignature: "GET /plugins",
+      scopes: ["core:read"],
+    })(handler);
+    const req: RequestLike = { headers: { authorization: "Bearer abc" } };
+    const rc = makeResCapture();
+    await wrapped(req, rc.res);
+    expect(called).toBe(true);
+    expect(rc.status).toBe(200);
+    // should not hit cookie path
+    expect((requireSession as any).mock.calls.length).toBe(0);
+  });
+
+  it("does not fall back to cookie when bearer fails (no requireSession call)", async () => {
+    // Token lookup returns null -> invalid token
+    (prisma.apiToken.findUnique as any).mockResolvedValueOnce(null);
+    const handler: HttpHandler = async (_req, _res) => {
+      throw new Error("handler should not be called");
+    };
+    const wrapped = requireAdminOrApiToken({
+      policySignature: "GET /plugins",
+      scopes: ["core:read"],
+    })(handler);
+    const req: RequestLike = { headers: { authorization: "Bearer abc" } };
+    const rc = makeResCapture();
+    let err: any;
+    try {
+      await wrapped(req, rc.res);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeTruthy();
+    // Ensure we didn't attempt cookie fallback
+    expect((requireSession as any).mock.calls.length).toBe(0);
+  });
+
+  it("falls back to admin cookie path when no Authorization header", async () => {
+    let called = false;
+    const handler: HttpHandler = async (_req, res) => {
+      called = true;
+      res.status(200).json({ ok: true });
+    };
+    const wrapped = requireAdminOrApiToken({
+      policySignature: "GET /plugins",
+      scopes: ["core:read"],
+    })(handler);
+    const req: RequestLike = {
+      headers: {
+        /* no auth */
+      },
+    };
+    const rc = makeResCapture();
+    await wrapped(req, rc.res);
+    expect(called).toBe(true);
+    expect(rc.status).toBe(200);
+  });
+});

--- a/packages/core/src/middleware/require-admin-or-api-token.ts
+++ b/packages/core/src/middleware/require-admin-or-api-token.ts
@@ -1,0 +1,52 @@
+import type { HttpHandler, RequestLike } from "../http/http-server.js";
+import type { RouteSignature } from "../authz/policy.js";
+import { requirePermission } from "./require-permission.js";
+import { requireApiToken } from "./require-api-token.js";
+import { logDecision } from "../authz/decisionLog.js";
+
+type Opts = {
+  policySignature: RouteSignature;
+  scopes: string[];
+};
+
+function hasAuthzHeader(req: RequestLike) {
+  const v = (req.headers?.["authorization"] as string | undefined) ?? "";
+  return /^Bearer\s+.+/i.test(v);
+}
+
+export function requireAdminOrApiToken(opts: Opts) {
+  return (handler: HttpHandler): HttpHandler => {
+    return async (req, res) => {
+      // If Authorization header is present, prefer bearer token path and do not fallback to cookie
+      if (hasAuthzHeader(req)) {
+        const wrapped = requireApiToken(opts.scopes)(async (req2, res2) => {
+          // Token validated and scopes checked; log ALLOW then proceed
+          const uid = (req2 as RequestLike & { user?: { id?: string } }).user?.id;
+          logDecision({
+            decision: "ALLOW",
+            reason: "API_TOKEN",
+            signature: opts.policySignature,
+            userId: uid,
+          });
+          return handler(req2, res2);
+        });
+        try {
+          return await wrapped(req, res);
+        } catch (e) {
+          // Log DENY for token path
+          const err = e as Error & { status?: number };
+          logDecision({
+            decision: "DENY",
+            reason: `API_TOKEN_${(err.status ?? 401) >= 500 ? "ERROR" : "REJECT"}`,
+            signature: opts.policySignature,
+          });
+          throw e;
+        }
+      }
+
+      // Otherwise, use admin cookie -> requirePermission (includes its own decision logs)
+      const wrapped = requirePermission(opts.policySignature)(handler);
+      return wrapped(req, res);
+    };
+  };
+}

--- a/packages/core/src/routes/admin/plugins.ts
+++ b/packages/core/src/routes/admin/plugins.ts
@@ -2,8 +2,9 @@ import { z } from "zod";
 import type { HttpServer } from "../../http/http-server.js";
 import { getDb } from "../../db/db.js";
 import type { Prisma } from "@latchflow/db";
-import { requirePermission } from "../../middleware/require-permission.js";
 import { type RouteSignature } from "../../authz/policy.js";
+import { requireAdminOrApiToken } from "../../middleware/require-admin-or-api-token.js";
+import { SCOPES } from "../../auth/scopes.js";
 
 export function registerPluginRoutes(server: HttpServer) {
   const db = getDb();
@@ -11,7 +12,10 @@ export function registerPluginRoutes(server: HttpServer) {
   // GET /plugins — list installed plugins with capabilities
   server.get(
     "/plugins",
-    requirePermission("GET /plugins" as RouteSignature)(async (req, res) => {
+    requireAdminOrApiToken({
+      policySignature: "GET /plugins" as RouteSignature,
+      scopes: [SCOPES.CORE_READ],
+    })(async (req, res) => {
       try {
         const Q = z.object({
           q: z.string().optional(),
@@ -75,7 +79,10 @@ export function registerPluginRoutes(server: HttpServer) {
   // POST /plugins/install — async install trigger
   server.post(
     "/plugins/install",
-    requirePermission("POST /plugins/install" as RouteSignature)(async (req, res) => {
+    requireAdminOrApiToken({
+      policySignature: "POST /plugins/install" as RouteSignature,
+      scopes: [SCOPES.CORE_WRITE],
+    })(async (req, res) => {
       try {
         const Body = z.object({
           source: z.string().min(1),
@@ -100,7 +107,10 @@ export function registerPluginRoutes(server: HttpServer) {
   // DELETE /plugins/{pluginId}
   server.delete(
     "/plugins/:pluginId",
-    requirePermission("DELETE /plugins/:pluginId" as RouteSignature)(async (req, res) => {
+    requireAdminOrApiToken({
+      policySignature: "DELETE /plugins/:pluginId" as RouteSignature,
+      scopes: [SCOPES.CORE_WRITE],
+    })(async (req, res) => {
       try {
         const Params = z.object({ pluginId: z.string().min(1) });
         const parsed = Params.safeParse(req.params);
@@ -126,7 +136,10 @@ export function registerPluginRoutes(server: HttpServer) {
   // GET /capabilities — consolidated list across plugins
   server.get(
     "/capabilities",
-    requirePermission("GET /capabilities" as RouteSignature)(async (req, res) => {
+    requireAdminOrApiToken({
+      policySignature: "GET /capabilities" as RouteSignature,
+      scopes: [SCOPES.CORE_READ],
+    })(async (req, res) => {
       try {
         const Q = z.object({
           kind: z.enum(["TRIGGER", "ACTION"]).optional(),


### PR DESCRIPTION
## Summary

Introduce bearer token scope checks for CLI/API access and unify authorization so endpoints can be accessed by either an admin session cookie or an API token with sufficient scopes. Add a small set of core scopes, route guards, and tests, and align OpenAPI and docs.

## Scope

- Define initial scopes and semantics (exact match, no wildcards yet):
    - core: `core:read`, `core:write`
    - resources (incrementally used): `files:read|write`, `bundles:read|write`, `plugins:read|manage`, `triggers:read|write`, `actions:read|write`, `pipelines:read|write`, `capabilities:read`
- Add a combinator guard to accept cookie admin OR bearer token:
    - `requireAdminOrApiToken({ policySignature, scopes })`
    - Algorithm: if Authorization header is present ➜ validate via token+scopes; else ➜ validate via admin session+policy. Missing/invalid ➜ 401/403.
- Keep existing `requirePermission` and `requireApiToken` intact; reuse them under the combinator.
- Map existing implemented routes to scopes (minimal now; extend as new routes land):
    - GET `/plugins`, GET `/capabilities` ➜ `core:read`
    - POST `/plugins/install`, DELETE `/plugins/:pluginId` ➜ `core:write` (later: `plugins:manage`)
- Update tests for middleware and affected routes.
- Ensure OpenAPI lists `bearer` and `cookieAdmin` where supported (already present for many paths).
- Default token scopes come from `API_TOKEN_SCOPES_DEFAULT` (keep `["core:read","core:write"]`), allow env overrides.

## To-Do

- [x]  Add scope constants and helper types (e.g., `src/auth/scopes.ts`).
- [x]  Implement `requireAdminOrApiToken({ policySignature, scopes })` in `src/middleware/`.
- [x]  Add decision logging on token path to match admin policy logging.
- [x]  Apply combinator to existing routes that should accept bearer:
  - `GET /plugins` (core:read)
  - `GET /capabilities` (core:read)
  - `POST /plugins/install` (core:write)
  - `DELETE /plugins/:pluginId` (core:write)
- [x]  Unit tests:
  - Token: valid scope ➜ 200; insufficient scope ➜ 403; expired/revoked ➜ 401.
  - Cookie: admin passes; executor blocked per policy.
  - Precedence: Authorization header present uses token path; otherwise cookie path.
- [x]  OpenAPI: verify `security` entries are present for the above endpoints.
- [x]  README: add short CLI token usage example (Bearer) and scope explanation.

## DoD

- [x]  Endpoints above accept either admin cookie or bearer with required scopes.
- [x]  Tests cover success and failure matrices for both auth paths and precedence rules.
- [x]  Decision logs include ALLOW/DENY for bearer evaluations (reason, scope, userId).
- [x]  OpenAPI security for these endpoints includes `bearer` and `cookieAdmin`.
- [x]  `API_TOKEN_SCOPES_DEFAULT` respected; overriding via env documented.
- [x]  No regressions in existing admin-session flows; `pnpm core:test` passes.