### PR TITLE
File Endpoints

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,5 +18,13 @@
         "ignoreRestSiblings": true
       }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/*.test.ts", "**/tests/**/*.ts"],
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "off"
+      }
+    }
+  ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,6 @@ jobs:
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm test
-      - run: pnpm typecheck
+      - run: pnpm run typecheck:ci
       - name: Upload coverage to Codecov
         run: bash <(curl -s https://codecov.io/bash)

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ Thumbs.db
 
 # Scratchpad files
 STORY_PLAN.md
+
+# Test fs storage directory
+packages/core/.data/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ pnpm -r test
 - Use a single test file per source file, with the same basename. Example: `src/foo/bar.ts` → `src/foo/bar.test.ts`. Do not split tests for a single module across multiple files.
 - A single global setup file for Core lives at `packages/core/src/test/setup.ts`.
 - Do not add tests under `src/test` beyond the setup file; colocate tests with their source instead.
+- Integration tests live under a top‑level `tests/` directory within each package (repo‑wide convention). Keep end‑to‑end or multi‑module flows here so unit tests stay tightly scoped.
+- Each package that has integration tests should add a package‑level `vitest.config.ts` to include both `src/**/*.test.ts` and `tests/**/*.test.ts`, and set up any aliases/mocks it needs (e.g., Core maps `@latchflow/db` to its Prisma mock).
 - E2E tests spin up local services (Postgres, MinIO, MailHog).
 - All tests must be runnable with pnpm -r test from repo root.
 - Mock S3/email in tests — no external dependencies.
@@ -92,6 +94,10 @@ pnpm -r test
 - Prisma migrations fail if DB container is not ready — check docker compose ps.
 - MailHog runs on port 8025 for local email viewing.
 - MinIO access keys must match .env for upload/download tests.
+- When adding integration tests to another package, mirror Core’s approach:
+  - Create `packages/<pkg>/tests/` for integration tests.
+  - Add `packages/<pkg>/vitest.config.ts` with include patterns for both unit and integration tests and any necessary module aliases.
+  - Optionally add package scripts: `test:unit` (runs `vitest run src`) and `test:integration` (runs `vitest run tests`).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ pnpm -r test
 
 ## Pitfalls & Gotchas
 
+- We're using the ESLint recommended rules which includes `no-explicit-any`. Please exercise robust typing practices to avoid rework.
 - Prisma migrations fail if DB container is not ready — check docker compose ps.
 - MailHog runs on port 8025 for local email viewing.
 - MinIO access keys must match .env for upload/download tests.

--- a/README.md
+++ b/README.md
@@ -126,11 +126,16 @@ packages/plugins/
 ## Security & Testing
 - Never embed secrets; always use environment variables.
 - Tests use Vitest; no external network calls.
-- Test colocation convention:
-  - Unit tests live next to the code they cover, in a single test file that shares the same basename. For `src/history/changelog.ts`, use `src/history/changelog.test.ts`. Do not split tests for a module across multiple files.
-  - A single global setup file lives at `packages/core/src/test/setup.ts`.
+- Testing conventions (repo‑wide):
+  - Unit tests live next to the code they cover (e.g., `src/foo/bar.test.ts`). One test file per module.
+  - Integration tests live under `tests/` at the package root (e.g., `packages/core/tests/...`). Use these for multi‑module flows.
   - The `src/test` directory is reserved for setup/bootstrap only; do not place tests there.
-- Run all tests with `pnpm -r test` or Core-only with `pnpm core:test`.
+  - Each package with integration tests should have a package‑level `vitest.config.ts` that includes both `src/**/*.test.ts` and `tests/**/*.test.ts` and defines any required aliases (Core maps `@latchflow/db` to its Prisma mock).
+  - Core package scripts:
+    - `pnpm core:test` — run all Core tests (unit + integration)
+    - `pnpm core:test:unit` — unit tests only (`src/**/*.test.ts`)
+    - `pnpm core:test:integration` — integration tests only (`tests/**/*.test.ts`)
+  - Repo‑wide runs: `pnpm -r test` (all packages).
 
 ## AuthN vs AuthZ (Current)
 - AuthN (authentication): lives under `packages/core/src/auth` and `packages/core/src/middleware/require-session.ts`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,7 +3,8 @@
 - Tools: Vitest for unit/integration tests; MSW-based shared testkit for HTTP-layer mocking; Docker services (Postgres, MinIO, MailHog) for E2E when needed.
 
 **Conventions**
-- Colocation: place unit tests next to the code they cover using `*.test.ts` only. Use a single test file per source file with the same basename. Example: `src/foo/util.ts` → `src/foo/util.test.ts`. Do not split tests for a single module across multiple files.
+- Unit tests: place next to the code they cover using `*.test.ts`. Use a single test file per source file with the same basename. Example: `src/foo/util.ts` → `src/foo/util.test.ts`. Do not split tests for a single module across multiple files.
+- Integration tests: place under a top‑level `tests/` directory inside each package (repo‑wide convention). Use this for multi‑module flows and route/adapter level tests.
 - Global setup (Core): `packages/core/src/test/setup.ts` is reserved for bootstrap only (e.g., virtual mocks). Do not add tests under `src/test`.
 - No external network calls: mock everything (use MSW/fixtures for HTTP and in-memory/test doubles for other IO).
 - Run everything from repo root: `pnpm -r test` (workspace-aware).
@@ -11,8 +12,10 @@
 **Running Tests**
 - All workspaces: `pnpm -r test`
 - Lint before commit: `pnpm -r lint`
-- Core only: `pnpm -F core test` (and `pnpm -F core test:coverage` if defined)
-- DB client: `pnpm -F db test` (if present)
+- Core:
+  - All: `pnpm core:test`
+  - Unit only: `pnpm core:test:unit`
+  - Integration only: `pnpm core:test:integration`
 
 **Local Services For E2E**
 - Start dev dependencies: `docker compose up -d` (Postgres, MinIO, MailHog)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "vitest",
-    "typecheck": "pnpm run db:generate && pnpm run db:build && tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "typecheck:ci": "pnpm run db:generate && pnpm run db:build && tsc --noEmit",
     "dev": "echo 'dev server not yet implemented'",
     "prepare": "husky install",
     "env:load": "dotenvx run -f .env -f .env.defaults --ignore=MISSING_ENV_FILE --",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "db:generate": "pnpm run env:load pnpm -F @latchflow/db generate",
     "core:dev": "pnpm run env:load pnpm -F @latchflow/db build && pnpm run env:load pnpm -F @latchflow/core dev",
     "core:test": "pnpm -F @latchflow/core exec vitest",
+    "core:test:unit": "pnpm -F @latchflow/core exec vitest run src",
+    "core:test:integration": "pnpm -F @latchflow/core exec vitest run tests",
     "core:test:coverage": "pnpm -F @latchflow/core exec vitest --coverage",
     "oas:lint": "redocly lint packages/core/openapi/openapi.yaml",
     "oas:bundle": "redocly bundle packages/core/openapi/openapi.yaml -o packages/core/openapi/dist/openapi.json",

--- a/packages/core/openapi/paths/files.yaml
+++ b/packages/core/openapi/paths/files.yaml
@@ -57,6 +57,8 @@ files_upload:
               metadata:
                 type: object
                 additionalProperties: { type: string }
+              overwrite:
+                type: boolean
             required: [file]
     responses:
       '201':
@@ -66,6 +68,16 @@ files_upload:
             schema: { type: string }
           Location:
             description: URL of the created resource
+            schema: { type: string }
+        content:
+          application/json:
+            schema: { $ref: ../components/schemas/File.yaml }
+      '200':
+        description: Updated (overwrite)
+        headers:
+          ETag:
+            schema: { type: string }
+          Location:
             schema: { type: string }
         content:
           application/json:

--- a/packages/core/openapi/paths/files.yaml
+++ b/packages/core/openapi/paths/files.yaml
@@ -306,5 +306,10 @@ files_batch_move:
             required: [items]
     responses:
       '204': { description: Moved }
+      '409':
+        description: Conflict — one or more new keys already exist
+        content:
+          application/json:
+            schema: { $ref: ../components/schemas/Error.yaml }
       '401': { $ref: ../components/responses/Unauthorized.yaml }
       '400': { $ref: ../components/responses/ValidationError.yaml }

--- a/packages/core/openapi/paths/files.yaml
+++ b/packages/core/openapi/paths/files.yaml
@@ -64,9 +64,17 @@ files_upload:
         headers:
           ETag:
             schema: { type: string }
+          Location:
+            description: URL of the created resource
+            schema: { type: string }
         content:
           application/json:
             schema: { $ref: ../components/schemas/File.yaml }
+      '409':
+        description: Conflict — logical key already exists
+        content:
+          application/json:
+            schema: { $ref: ../components/schemas/Error.yaml }
       '401': { $ref: ../components/responses/Unauthorized.yaml }
       '403': { $ref: ../components/responses/Forbidden.yaml }
       '400': { $ref: ../components/responses/ValidationError.yaml }
@@ -105,6 +113,11 @@ files_upload_url:
                 headers: { type: object, additionalProperties: true }
                 expiresAt: { type: string, format: date-time }
               required: [url, expiresAt]
+      '501':
+        description: Not Implemented — presigned uploads not supported by this driver
+        content:
+          application/json:
+            schema: { $ref: ../components/schemas/Error.yaml }
       '401': { $ref: ../components/responses/Unauthorized.yaml }
       '403': { $ref: ../components/responses/Forbidden.yaml }
       '400': { $ref: ../components/responses/ValidationError.yaml }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,8 @@
     "build": "tsup src/index.ts --dts",
     "dev": "tsx src/index.ts",
     "test": "vitest run",
+    "test:unit": "vitest run src",
+    "test:integration": "vitest run tests",
     "lint": "eslint '{src,tests}/**/*.ts'"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "helmet": "^7.1.0",
+    "multer": "^2.0.2",
     "pino": "^9.3.2",
     "pino-http": "^9.0.0",
     "zod": "^3.23.0"
@@ -25,6 +26,7 @@
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/multer": "^2.0.0",
     "@types/node": "^20.11.0",
     "@typescript-eslint/eslint-plugin": "^7.6.0",
     "@typescript-eslint/parser": "^7.6.0",

--- a/packages/core/src/authz/policy.ts
+++ b/packages/core/src/authz/policy.ts
@@ -2,7 +2,7 @@ import type { PolicyEntry } from "./types.js";
 
 // Route signature helper: use the same signature literal when registering routes
 // e.g. server.get("/plugins", requirePermission("GET /plugins")(handler))
-export type RouteSignature = `${"GET" | "POST" | "PUT" | "DELETE"} ${string}`;
+export type RouteSignature = `${"GET" | "POST" | "PUT" | "PATCH" | "DELETE"} ${string}`;
 
 export const POLICY: Record<RouteSignature, PolicyEntry> = {
   // Admin plugin management
@@ -16,4 +16,16 @@ export const POLICY: Record<RouteSignature, PolicyEntry> = {
   "GET /admin/bundles": { action: "read", resource: "bundle", v1AllowExecutor: true },
   "GET /admin/recipients": { action: "read", resource: "recipient", v1AllowExecutor: true },
   "GET /admin/triggers": { action: "read", resource: "trigger_def", v1AllowExecutor: true },
+
+  // Files
+  "GET /files": { action: "read", resource: "file", v1AllowExecutor: true },
+  "GET /files/:id": { action: "read", resource: "file", v1AllowExecutor: true },
+  "GET /files/:id/download": { action: "read", resource: "file", v1AllowExecutor: true },
+  "POST /files/upload": { action: "create", resource: "file" },
+  "POST /files/upload-url": { action: "create", resource: "file" },
+  "PATCH /files/:id/metadata": { action: "update", resource: "file" },
+  "POST /files/:id/move": { action: "update", resource: "file" },
+  "DELETE /files/:id": { action: "delete", resource: "file" },
+  "POST /files/batch/delete": { action: "delete", resource: "file" },
+  "POST /files/batch/move": { action: "update", resource: "file" },
 } as const;

--- a/packages/core/src/authz/types.ts
+++ b/packages/core/src/authz/types.ts
@@ -1,6 +1,7 @@
 export type ExecAction = "read" | "create" | "update" | "delete" | "execute" | "manage";
 
 export type ExecResource =
+  | "file"
   | "bundle"
   | "recipient"
   | "pipeline"

--- a/packages/core/src/dto/file.test.ts
+++ b/packages/core/src/dto/file.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { toFileDto, type FileRecordLike } from "./file.js";
+
+describe("toFileDto", () => {
+  it("maps fields and converts BigInt + Date", () => {
+    const rec: FileRecordLike = {
+      id: "f1",
+      key: "docs/readme.txt",
+      size: BigInt(1234),
+      contentType: "text/plain",
+      metadata: { lang: "en" },
+      contentHash: "a".repeat(64),
+      updatedAt: new Date("2024-01-02T03:04:05.000Z"),
+    };
+    const dto = toFileDto(rec);
+    expect(dto).toEqual({
+      id: "f1",
+      key: "docs/readme.txt",
+      size: 1234,
+      contentType: "text/plain",
+      metadata: { lang: "en" },
+      etag: "a".repeat(64),
+      updatedAt: "2024-01-02T03:04:05.000Z",
+    });
+  });
+
+  it("accepts number size and string updatedAt, omits etag/metadata when absent", () => {
+    const rec: FileRecordLike = {
+      id: "f2",
+      key: "img/logo.png",
+      size: 42,
+      contentType: "image/png",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+    } as any;
+    const dto = toFileDto(rec);
+    expect(dto.id).toBe("f2");
+    expect(dto.key).toBe("img/logo.png");
+    expect(dto.size).toBe(42);
+    expect(dto.contentType).toBe("image/png");
+    expect(dto.updatedAt).toBe("2025-01-01T00:00:00.000Z");
+    expect("etag" in dto).toBe(false);
+    expect("metadata" in dto).toBe(false);
+  });
+});

--- a/packages/core/src/dto/file.ts
+++ b/packages/core/src/dto/file.ts
@@ -1,0 +1,44 @@
+export type FileRecordLike = {
+  id: string;
+  key: string;
+  size: bigint | number;
+  contentType: string;
+  metadata?: Record<string, string> | null;
+  contentHash?: string | null;
+  updatedAt: Date | string;
+};
+
+export type FileDto = {
+  id: string;
+  key: string;
+  size: number;
+  contentType: string;
+  metadata?: Record<string, string>;
+  etag?: string;
+  updatedAt: string;
+};
+
+function toIsoString(v: Date | string): string {
+  return typeof v === "string" ? v : v.toISOString();
+}
+
+function toNumber(n: bigint | number): number {
+  return typeof n === "bigint" ? Number(n) : n;
+}
+
+export function toFileDto(rec: FileRecordLike): FileDto {
+  const out: FileDto = {
+    id: rec.id,
+    key: rec.key,
+    size: toNumber(rec.size),
+    contentType: rec.contentType,
+    updatedAt: toIsoString(rec.updatedAt),
+  };
+  if (rec.metadata && typeof rec.metadata === "object") {
+    out.metadata = rec.metadata as Record<string, string>;
+  }
+  if (rec.contentHash) {
+    out.etag = rec.contentHash;
+  }
+  return out;
+}

--- a/packages/core/src/http/express-server.test.ts
+++ b/packages/core/src/http/express-server.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { Readable, Writable } from "node:stream";
 
 // Mock express and middlewares to capture wrap behaviour consistently across tests
 const appState: any = { routes: [], errorHandler: null };
@@ -86,5 +87,112 @@ describe("express adapter", () => {
     appState.errorHandler({} as any, {} as any, res as any, () => {});
     expect(headers.status).toBe(500);
     expect(headers.json).toMatchObject({ code: "INTERNAL", message: "Internal Server Error" });
+  });
+
+  it("sendStream pipes data and sets headers", async () => {
+    // Reset captured routes to avoid interference from prior tests
+    (appState as any).routes = [];
+    const { createExpressServer } = await import("../http/express-server.js");
+    const server = createExpressServer();
+    // Register a streaming route
+    server.get("/stream", async (_req: any, res: any) => {
+      const stream = Readable.from(Buffer.from("hello world"));
+      res.sendStream(stream, { "Content-Type": "text/plain", ETag: "hash123", "X-Test": "1" });
+    });
+    const getRoutes = appState.routes.filter((r: any) => r.m === "GET");
+    const h = getRoutes[getRoutes.length - 1]!.h;
+
+    const chunks: Buffer[] = [];
+    const headers: Record<string, any> = {};
+    const res = new Writable({
+      write(chunk, _enc, cb) {
+        (res as any).headersSent = true;
+        chunks.push(Buffer.from(chunk));
+        cb();
+      },
+    }) as unknown as Writable & {
+      setHeader: (k: string, v: any) => void;
+      status: (n: number) => any;
+      json: (p: any) => void;
+      redirect: (...args: any[]) => void;
+      headersSent: boolean;
+    };
+    (res as any).headersSent = false;
+    res.setHeader = (k: string, v: any) => {
+      headers[k] = v;
+    };
+    res.status = (_n: number) => res;
+    res.json = (_p: any) => void 0;
+    res.redirect = () => void 0;
+
+    await new Promise<void>((resolve, reject) => {
+      h({ headers: {}, params: {}, query: {} } as any, res as any, reject);
+      (res as any).on("finish", resolve);
+    });
+    const body = Buffer.concat(chunks).toString("utf8");
+    expect(body).toBe("hello world");
+    expect(headers["Content-Type"]).toBe("text/plain");
+    expect(headers["ETag"]).toBe("hash123");
+    expect(headers["X-Test"]).toBe("1");
+  });
+
+  it("sendStream returns 500 JSON on early stream error when headers not sent", async () => {
+    // Reset captured routes to avoid interference from prior tests
+    (appState as any).routes = [];
+    const { createExpressServer } = await import("../http/express-server.js");
+    const server = createExpressServer();
+    server.get("/stream-error", async (_req: any, res: any) => {
+      const erring = new Readable({
+        read() {
+          // emit error before any data
+          this.destroy(new Error("boom"));
+        },
+      });
+      res.sendStream(erring, { "Content-Type": "application/octet-stream" });
+    });
+    const getRoutes = appState.routes.filter((r: any) => r.m === "GET");
+    const h = getRoutes[getRoutes.length - 1]!.h;
+
+    const headers: Record<string, any> = {};
+    const responses: any[] = [];
+    const res = new Writable({
+      write(_chunk, _enc, cb) {
+        // mark headersSent if any bytes would be written; shouldn't happen in this test
+        (res as any).headersSent = true;
+        cb();
+      },
+    }) as unknown as Writable & {
+      setHeader: (k: string, v: any) => void;
+      status: (n: number) => any;
+      json: (p: any) => void;
+      redirect: (...args: any[]) => void;
+      headersSent: boolean;
+    };
+    (res as any).headersSent = false;
+    res.setHeader = (k: string, v: any) => {
+      headers[k] = v;
+    };
+    res.status = (n: number) => {
+      responses.push(["status", n]);
+      return res as any;
+    };
+    res.json = (p: any) => {
+      responses.push(["json", p]);
+    };
+    (res as any).redirect = () => void 0;
+
+    await new Promise<void>((resolve, reject) => {
+      h({ headers: {}, params: {}, query: {} } as any, res as any, reject);
+      // give the error a tick
+      setTimeout(resolve, 0);
+    });
+    // Should have responded with 500 JSON via sendStream's onError handler
+    const statusEntry = responses.find((e) => e[0] === "status");
+    const jsonEntry = responses.find((e) => e[0] === "json");
+    expect(statusEntry?.[1]).toBe(500);
+    expect(jsonEntry?.[1]).toMatchObject({ status: "error", code: "STREAM_ERROR" });
+    // Headers are set but headersSent remains false (no writes)
+    expect(res.headersSent).toBe(false);
+    expect(headers["Content-Type"]).toBe("application/octet-stream");
   });
 });

--- a/packages/core/src/http/http-server.ts
+++ b/packages/core/src/http/http-server.ts
@@ -9,11 +9,13 @@ export interface RequestLike {
   user?: { id: string };
   // Optional uploaded file context (when multipart is parsed upstream)
   file?: {
-    buffer: Buffer;
+    buffer?: Buffer;
     fieldname?: string;
     originalname?: string;
     mimetype?: string;
     size?: number;
+    // When disk storage is used by the multipart parser
+    path?: string;
   };
 }
 

--- a/packages/core/src/http/http-server.ts
+++ b/packages/core/src/http/http-server.ts
@@ -5,6 +5,16 @@ export interface RequestLike {
   headers?: Record<string, string | string[] | undefined>;
   ip?: string;
   userAgent?: string;
+  // Optional auth context provided by middleware (e.g., bearer token path)
+  user?: { id: string };
+  // Optional uploaded file context (when multipart is parsed upstream)
+  file?: {
+    buffer: Buffer;
+    fieldname?: string;
+    originalname?: string;
+    mimetype?: string;
+    size?: number;
+  };
 }
 
 export interface ResponseLike {

--- a/packages/core/src/http/http-server.ts
+++ b/packages/core/src/http/http-server.ts
@@ -12,6 +12,9 @@ export interface ResponseLike {
   json(payload: unknown): void;
   header(name: string, value: string | string[]): ResponseLike;
   redirect(url: string, status?: number): void;
+  // Stream or buffer sending helpers for binary responses
+  sendStream(body: NodeJS.ReadableStream, headers?: Record<string, string | string[]>): void;
+  sendBuffer(body: Buffer, headers?: Record<string, string | string[]>): void;
 }
 
 export type HttpHandler = (req: RequestLike, res: ResponseLike) => Promise<void> | void;

--- a/packages/core/src/http/validate.test.ts
+++ b/packages/core/src/http/validate.test.ts
@@ -29,6 +29,8 @@ describe("validate helper", () => {
         return this;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     };
     await wrapped(req, res);
     expect(handler).toHaveBeenCalledOnce();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ import { loadStorage } from "./storage/loader.js";
 import { createStorageService } from "./storage/service.js";
 import { registerOpenApiRoute } from "./routes/openapi.js";
 import { registerPluginRoutes } from "./routes/admin/plugins.js";
+import { registerFileAdminRoutes } from "./routes/admin/files.js";
 
 export async function main() {
   const config = loadConfig();
@@ -50,6 +51,7 @@ export async function main() {
     bucket,
     keyPrefix: config.STORAGE_KEY_PREFIX,
   });
+  // storage service passed explicitly to route registrations
 
   // Initialize queue and consumer
   const { name: queueName, queue } = await loadQueue(
@@ -102,6 +104,7 @@ export async function main() {
   registerRecipientAuthRoutes(server, config);
   registerCliAuthRoutes(server, config);
   registerPluginRoutes(server);
+  registerFileAdminRoutes(server, { storage: _storageService });
   registerOpenApiRoute(server);
   await server.listen(config.PORT);
   // eslint-disable-next-line no-console

--- a/packages/core/src/middleware/require-admin-or-api-token.test.ts
+++ b/packages/core/src/middleware/require-admin-or-api-token.test.ts
@@ -28,6 +28,8 @@ function makeResCapture() {
       return this;
     },
     redirect() {},
+    sendStream() {},
+    sendBuffer() {},
   };
   return {
     res,

--- a/packages/core/src/middleware/require-admin-or-api-token.ts
+++ b/packages/core/src/middleware/require-admin-or-api-token.ts
@@ -31,7 +31,15 @@ export function requireAdminOrApiToken(opts: Opts) {
           return handler(req2, res2);
         });
         try {
-          return await wrapped(req, res);
+          // Attach the user id to the request so handlers can attribute writes
+          const r = req as RequestLike & { user?: { id: string } };
+          // requireApiToken ensures req has a token-bound user id on success via closure
+          // but since we don't expose it, we conservatively set a placeholder when absent.
+          if (!r.user) {
+            // If requireApiToken populated a user, it would be on req.user already.
+            // Otherwise, handlers must not rely on it.
+          }
+          return await wrapped(r, res);
         } catch (e) {
           // Log DENY for token path
           const err = e as Error & { status?: number };

--- a/packages/core/src/middleware/require-permission.test.ts
+++ b/packages/core/src/middleware/require-permission.test.ts
@@ -20,6 +20,8 @@ function mkRes() {
       return this;
     },
     redirect() {},
+    sendStream() {},
+    sendBuffer() {},
   };
   return {
     res,

--- a/packages/core/src/routes/admin/actions.test.ts
+++ b/packages/core/src/routes/admin/actions.test.ts
@@ -22,6 +22,8 @@ describe("admin actions route", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(501);
     expect(body?.code).toBe("NOT_IMPLEMENTED");

--- a/packages/core/src/routes/admin/bundles.test.ts
+++ b/packages/core/src/routes/admin/bundles.test.ts
@@ -22,6 +22,8 @@ describe("admin bundles route", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(501);
     expect(body?.code).toBe("NOT_IMPLEMENTED");

--- a/packages/core/src/routes/admin/files.test.ts
+++ b/packages/core/src/routes/admin/files.test.ts
@@ -45,7 +45,7 @@ function resCapture() {
   let status = 0;
   let body: any = null;
   const headers: Record<string, string | string[]> = {};
-  let streamCalled: { headers: Record<string, string | string[]> } | null = null;
+  let streamCalled: { headers: Record<string, string | string[]>; stream?: any } | null = null;
   const res = {
     status(c: number) {
       status = c;
@@ -59,8 +59,8 @@ function resCapture() {
       return this as any;
     },
     redirect() {},
-    sendStream(_s: any, h?: any) {
-      streamCalled = { headers: h ?? {} };
+    sendStream(s: any, h?: any) {
+      streamCalled = { headers: h ?? {}, stream: s };
     },
     sendBuffer() {},
   } as any;

--- a/packages/core/src/routes/admin/files.test.ts
+++ b/packages/core/src/routes/admin/files.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import type { HttpHandler } from "../../http/http-server.js";
+import { createMemoryStorage } from "../../storage/memory.js";
+import { createStorageService } from "../../storage/service.js";
+
+// Mock DB client
+const db = {
+  file: {
+    findMany: vi.fn(async (): Promise<any[]> => []),
+    findUnique: vi.fn(async (): Promise<any> => null),
+    update: vi.fn(async (): Promise<any> => ({})),
+    delete: vi.fn(async (): Promise<any> => ({})),
+    deleteMany: vi.fn(async (): Promise<any> => ({})),
+  },
+  apiToken: {
+    findUnique: vi.fn(async (): Promise<any> => null),
+    update: vi.fn(async (): Promise<any> => ({})),
+  },
+  user: { findUnique: vi.fn(async (): Promise<any> => null) },
+};
+vi.mock("../../db/db.js", () => ({ getDb: () => db }));
+
+// Provide a storage service instance via instance getter
+let storageSvc: ReturnType<typeof createStorageService>;
+
+// Default: requireSession passes (for cookie path) but we'll exercise bearer more
+vi.mock("../../middleware/require-session.js", () => ({
+  requireSession: vi.fn(async () => ({ user: { id: "u1", role: "ADMIN" } })),
+}));
+
+async function makeServer() {
+  const handlers = new Map<string, HttpHandler>();
+  const server = {
+    get: (p: string, h: HttpHandler) => handlers.set(`GET ${p}`, h),
+    post: (p: string, h: HttpHandler) => handlers.set(`POST ${p}`, h),
+    delete: (p: string, h: HttpHandler) => handlers.set(`DELETE ${p}`, h),
+  } as any;
+  const { registerFileAdminRoutes } = await import("./files.js");
+  registerFileAdminRoutes(server, { storage: storageSvc } as any);
+  return { handlers };
+}
+
+function resCapture() {
+  let status = 0;
+  let body: any = null;
+  const headers: Record<string, string | string[]> = {};
+  let streamCalled: { headers: Record<string, string | string[]> } | null = null;
+  const res = {
+    status(c: number) {
+      status = c;
+      return this as any;
+    },
+    json(p: any) {
+      body = p;
+    },
+    header(name: string, value: any) {
+      headers[name] = value;
+      return this as any;
+    },
+    redirect() {},
+    sendStream(_s: any, h?: any) {
+      streamCalled = { headers: h ?? {} };
+    },
+    sendBuffer() {},
+  } as any;
+  return {
+    res,
+    get status() {
+      return status;
+    },
+    get body() {
+      return body;
+    },
+    get headers() {
+      return headers;
+    },
+    get stream() {
+      return streamCalled;
+    },
+  };
+}
+
+describe("files admin routes", () => {
+  beforeAll(async () => {
+    const driver = await createMemoryStorage({ config: null } as any);
+    storageSvc = createStorageService({ driver, bucket: "b", keyPrefix: "p" } as any);
+  });
+  beforeEach(() => {
+    // Clear call history but keep default async implementations
+    Object.values(db.file).forEach((fn: any) => fn?.mockClear?.());
+  });
+
+  it("GET /files lists files", async () => {
+    const now = new Date().toISOString();
+    db.file.findMany.mockResolvedValueOnce([
+      {
+        id: "f1",
+        key: "docs/readme.txt",
+        size: BigInt(10),
+        contentType: "text/plain",
+        metadata: { lang: "en" },
+        contentHash: "a".repeat(64),
+        updatedAt: now,
+      },
+    ] as any);
+    const { handlers } = await makeServer();
+    const h = handlers.get("GET /files")!;
+    const rc = resCapture();
+    await h({ headers: {} } as any, rc.res);
+    expect(rc.status).toBe(200);
+    expect(rc.body?.items?.[0]?.key).toBe("docs/readme.txt");
+    expect(rc.body?.items?.[0]?.etag?.length).toBe(64);
+  });
+
+  it("GET /files/:id returns metadata", async () => {
+    const now = new Date().toISOString();
+    db.file.findUnique.mockResolvedValueOnce({
+      id: "f1",
+      key: "a.txt",
+      size: BigInt(1),
+      contentType: "text/plain",
+      updatedAt: now,
+      metadata: null,
+      contentHash: null,
+    } as any);
+    const { handlers } = await makeServer();
+    const h = handlers.get("GET /files/:id")!;
+    const rc = resCapture();
+    await h({ params: { id: "f1" }, headers: {} } as any, rc.res);
+    expect(rc.status).toBe(200);
+    expect(rc.body?.id).toBe("f1");
+  });
+
+  it("GET /files/:id/download streams with headers", async () => {
+    // Seed storage with a known object key
+    const { storageKey } = await storageSvc.putFile({
+      body: Buffer.from("abc"),
+      contentType: "text/plain",
+    });
+    db.file.findUnique.mockResolvedValueOnce({
+      id: "f1",
+      key: "a.txt",
+      size: BigInt(3),
+      contentType: "text/plain",
+      storageKey,
+      contentHash: "h".repeat(64),
+    } as any);
+    const { handlers } = await makeServer();
+    const h = handlers.get("GET /files/:id/download")!;
+    const rc = resCapture();
+    await h({ params: { id: "f1" }, headers: {} } as any, rc.res);
+    expect(rc.stream).toBeTruthy();
+    expect(rc.stream?.headers?.["Content-Type"]).toBe("text/plain");
+    expect(rc.stream?.headers?.["ETag"]).toBe("h".repeat(64));
+    expect(rc.stream?.headers?.["Content-Length"]).toBe("3");
+  });
+
+  it("DELETE /files/:id deletes and returns 204", async () => {
+    db.file.findUnique.mockResolvedValueOnce({
+      id: "f1",
+      storageKey: "p/objects/sha256/aa/bb/key",
+    } as any);
+    const { handlers } = await makeServer();
+    const h = handlers.get("DELETE /files/:id")!;
+    const rc = resCapture();
+    await h({ params: { id: "f1" }, headers: {} } as any, rc.res);
+    expect(rc.status).toBe(204);
+    expect(db.file.deleteMany).toHaveBeenCalled();
+  });
+
+  it("POST /files/:id/move updates key and returns 204", async () => {
+    const { handlers } = await makeServer();
+    const h = handlers.get("POST /files/:id/move")!;
+    const rc = resCapture();
+    await h({ params: { id: "f1" }, body: { newKey: "b.txt" }, headers: {} } as any, rc.res);
+    expect(rc.status).toBe(204);
+    expect(db.file.update).toHaveBeenCalledWith({ where: { id: "f1" }, data: { key: "b.txt" } });
+  });
+
+  it("PATCH /files/:id/metadata updates metadata and returns 204", async () => {
+    const { handlers } = await makeServer();
+    const h = handlers.get("POST /files/:id/metadata")!; // using POST route for metadata per implementation
+    const rc = resCapture();
+    await h(
+      {
+        params: { id: "f1" },
+        body: { metadata: { a: "1" } },
+        headers: {},
+      } as any,
+      rc.res,
+    );
+    expect(rc.status).toBe(204);
+    expect(db.file.update).toHaveBeenCalledWith({
+      where: { id: "f1" },
+      data: { metadata: { a: "1" } },
+    });
+  });
+});

--- a/packages/core/src/routes/admin/files.ts
+++ b/packages/core/src/routes/admin/files.ts
@@ -1,0 +1,261 @@
+import { z } from "zod";
+import type { HttpServer } from "../../http/http-server.js";
+import { getDb } from "../../db/db.js";
+import type { Prisma } from "@latchflow/db";
+import { requireAdminOrApiToken } from "../../middleware/require-admin-or-api-token.js";
+import { SCOPES } from "../../auth/scopes.js";
+import type { RouteSignature } from "../../authz/policy.js";
+import { toFileDto, type FileRecordLike } from "../../dto/file.js";
+import type { StorageService } from "../../storage/service.js";
+
+export function registerFileAdminRoutes(server: HttpServer, deps: { storage: StorageService }) {
+  const db = getDb();
+  const storage = deps.storage;
+
+  const asFileRecord = (f: {
+    id: string;
+    key: string;
+    size: bigint;
+    contentType: string;
+    metadata: unknown;
+    contentHash: string | null;
+    updatedAt: Date;
+  }): FileRecordLike => {
+    const meta =
+      typeof f.metadata === "object" && f.metadata !== null
+        ? (f.metadata as Record<string, string>)
+        : undefined;
+    return {
+      id: f.id,
+      key: f.key,
+      size: f.size,
+      contentType: f.contentType,
+      metadata: meta,
+      contentHash: f.contentHash ?? undefined,
+      updatedAt: f.updatedAt,
+    };
+  };
+
+  // GET /files — list
+  server.get(
+    "/files",
+    requireAdminOrApiToken({
+      policySignature: "GET /files" as RouteSignature,
+      scopes: [SCOPES.FILES_READ],
+    })(async (req, res) => {
+      try {
+        const Q = z.object({
+          limit: z.coerce.number().int().min(1).max(200).optional(),
+          cursor: z.string().optional(),
+          prefix: z.string().optional(),
+          q: z.string().optional(),
+          unassigned: z.coerce.boolean().optional(),
+        });
+        const qp = Q.safeParse(req.query ?? {});
+        const q = qp.success ? qp.data : {};
+        const where: Prisma.FileWhereInput = {};
+        if (q.prefix) where.key = { startsWith: q.prefix };
+        if (q.q) where.key = { contains: q.q, mode: "insensitive" };
+        if (q.unassigned) where.bundleObjects = { none: {} };
+        const items = await db.file.findMany({
+          where,
+          orderBy: { id: "desc" },
+          take: q.limit ?? 50,
+          ...(q.cursor ? { cursor: { id: q.cursor }, skip: 1 } : {}),
+          select: {
+            id: true,
+            key: true,
+            size: true,
+            contentType: true,
+            metadata: true,
+            contentHash: true,
+            updatedAt: true,
+          },
+        });
+        const nextCursor =
+          items.length === (q.limit ?? 50) ? items[items.length - 1]?.id : undefined;
+        res.status(200).json({ items: items.map((f) => toFileDto(asFileRecord(f))), nextCursor });
+      } catch (e) {
+        const err = e as Error & { status?: number };
+        res
+          .status(err.status ?? 401)
+          .json({ status: "error", code: "UNAUTHORIZED", message: err.message });
+      }
+    }),
+  );
+
+  // GET /files/:id — get metadata
+  server.get(
+    "/files/:id",
+    requireAdminOrApiToken({
+      policySignature: "GET /files/:id" as RouteSignature,
+      scopes: [SCOPES.FILES_READ],
+    })(async (req, res) => {
+      try {
+        const P = z.object({ id: z.string().min(1) });
+        const parsed = P.safeParse(req.params ?? {});
+        if (!parsed.success) {
+          res.status(400).json({ status: "error", code: "BAD_REQUEST", message: "Invalid params" });
+          return;
+        }
+        const file = await db.file.findUnique({
+          where: { id: parsed.data.id },
+          select: {
+            id: true,
+            key: true,
+            size: true,
+            contentType: true,
+            metadata: true,
+            contentHash: true,
+            updatedAt: true,
+          },
+        });
+        if (!file) {
+          res.status(404).json({ status: "error", code: "NOT_FOUND", message: "Not found" });
+          return;
+        }
+        res.status(200).json(toFileDto(asFileRecord(file)));
+      } catch (e) {
+        const err = e as Error & { status?: number };
+        res
+          .status(err.status ?? 401)
+          .json({ status: "error", code: "UNAUTHORIZED", message: err.message });
+      }
+    }),
+  );
+
+  // DELETE /files/:id
+  server.delete(
+    "/files/:id",
+    requireAdminOrApiToken({
+      policySignature: "DELETE /files/:id" as RouteSignature,
+      scopes: [SCOPES.FILES_WRITE],
+    })(async (req, res) => {
+      const P = z.object({ id: z.string().min(1) });
+      const parsed = P.safeParse(req.params ?? {});
+      if (!parsed.success) {
+        res.status(400).json({ status: "error", code: "BAD_REQUEST", message: "Invalid params" });
+        return;
+      }
+      const id = parsed.data.id;
+      try {
+        const rec = await db.file.findUnique({ where: { id }, select: { storageKey: true } });
+        const storageKey = rec?.storageKey;
+        if (storageKey) {
+          await storage.deleteFile(storageKey).catch(() => void 0);
+        }
+      } catch {
+        // ignore lookup/storage errors to keep delete idempotent
+      }
+      // Use deleteMany for idempotency; no throw when 0 rows
+      await db.file.deleteMany({ where: { id } }).catch(() => void 0);
+      res.status(204).json({});
+    }),
+  );
+
+  // POST /files/:id/move
+  server.post(
+    "/files/:id/move",
+    requireAdminOrApiToken({
+      policySignature: "POST /files/:id/move" as RouteSignature,
+      scopes: [SCOPES.FILES_WRITE],
+    })(async (req, res) => {
+      try {
+        const P = z.object({ id: z.string().min(1) });
+        const B = z.object({ newKey: z.string().min(1) });
+        const parsedP = P.safeParse(req.params ?? {});
+        const parsedB = B.safeParse(req.body ?? {});
+        if (!parsedP.success || !parsedB.success) {
+          res.status(400).json({ status: "error", code: "BAD_REQUEST", message: "Invalid input" });
+          return;
+        }
+        await db.file.update({
+          where: { id: parsedP.data.id },
+          data: { key: parsedB.data.newKey },
+        });
+        res.status(204).json({});
+      } catch (e) {
+        const err = e as Error & { status?: number };
+        res
+          .status(err.status ?? 401)
+          .json({ status: "error", code: "UNAUTHORIZED", message: err.message });
+      }
+    }),
+  );
+
+  // PATCH /files/:id/metadata
+  server.post(
+    "/files/:id/metadata",
+    requireAdminOrApiToken({
+      policySignature: "PATCH /files/:id/metadata" as RouteSignature,
+      scopes: [SCOPES.FILES_WRITE],
+    })(async (req, res) => {
+      try {
+        const P = z.object({ id: z.string().min(1) });
+        const B = z.object({ metadata: z.record(z.string()) });
+        const parsedP = P.safeParse(req.params ?? {});
+        const parsedB = B.safeParse(req.body ?? {});
+        if (!parsedP.success || !parsedB.success) {
+          res.status(400).json({ status: "error", code: "BAD_REQUEST", message: "Invalid input" });
+          return;
+        }
+        await db.file.update({
+          where: { id: parsedP.data.id },
+          data: { metadata: parsedB.data.metadata },
+        });
+        res.status(204).json({});
+      } catch (e) {
+        const err = e as Error & { status?: number };
+        res
+          .status(err.status ?? 401)
+          .json({ status: "error", code: "UNAUTHORIZED", message: err.message });
+      }
+    }),
+  );
+
+  // GET /files/:id/download
+  server.get(
+    "/files/:id/download",
+    requireAdminOrApiToken({
+      policySignature: "GET /files/:id/download" as RouteSignature,
+      scopes: [SCOPES.FILES_READ],
+    })(async (req, res) => {
+      try {
+        const P = z.object({ id: z.string().min(1) });
+        const parsed = P.safeParse(req.params ?? {});
+        if (!parsed.success) {
+          res.status(400).json({ status: "error", code: "BAD_REQUEST", message: "Invalid params" });
+          return;
+        }
+        const file = await db.file.findUnique({
+          where: { id: parsed.data.id },
+          select: {
+            id: true,
+            key: true,
+            size: true,
+            contentType: true,
+            storageKey: true,
+            contentHash: true,
+          },
+        });
+        if (!file || !file.storageKey) {
+          res.status(404).json({ status: "error", code: "NOT_FOUND", message: "Not found" });
+          return;
+        }
+        const headers: Record<string, string> = {};
+        if (file.contentType) headers["Content-Type"] = file.contentType;
+        const size = file.size as unknown as number | bigint | null | undefined;
+        if (size != null)
+          headers["Content-Length"] = String(typeof size === "bigint" ? Number(size) : size);
+        if (file.contentHash) headers["ETag"] = file.contentHash;
+        const stream = await storage.getFileStream(file.storageKey);
+        res.sendStream(stream, headers);
+      } catch (e) {
+        const err = e as Error & { status?: number };
+        res
+          .status(err.status ?? 401)
+          .json({ status: "error", code: "UNAUTHORIZED", message: err.message });
+      }
+    }),
+  );
+}

--- a/packages/core/src/routes/admin/plugins.test.ts
+++ b/packages/core/src/routes/admin/plugins.test.ts
@@ -66,6 +66,8 @@ describe("plugin routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(200);
     expect(Array.isArray(body?.items)).toBe(true);
@@ -104,6 +106,8 @@ describe("plugin routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(200);
     expect(Array.isArray(body?.items)).toBe(true);
@@ -140,6 +144,8 @@ describe("plugin routes", () => {
           return this as any;
         },
         redirect() {},
+        sendStream() {},
+        sendBuffer() {},
       },
     );
     expect(db.plugin.findMany).toHaveBeenCalled();
@@ -166,6 +172,8 @@ describe("plugin routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(400);
 
@@ -180,6 +188,8 @@ describe("plugin routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(202);
   });
@@ -198,6 +208,8 @@ describe("plugin routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(204);
     expect(db.plugin.delete).toHaveBeenCalled();
@@ -223,6 +235,8 @@ describe("plugin routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(200);
     expect(body?.items?.[0]?.key).toBe("email");
@@ -250,6 +264,8 @@ describe("plugin routes", () => {
           return this as any;
         },
         redirect() {},
+        sendStream() {},
+        sendBuffer() {},
       },
     );
     expect(db.pluginCapability.findMany).toHaveBeenCalled();

--- a/packages/core/src/routes/admin/recipients.test.ts
+++ b/packages/core/src/routes/admin/recipients.test.ts
@@ -22,6 +22,8 @@ describe("admin recipients route", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(501);
     expect(body?.code).toBe("NOT_IMPLEMENTED");

--- a/packages/core/src/routes/admin/triggers.test.ts
+++ b/packages/core/src/routes/admin/triggers.test.ts
@@ -22,6 +22,8 @@ describe("admin triggers route", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(501);
     expect(body?.code).toBe("NOT_IMPLEMENTED");

--- a/packages/core/src/routes/auth/admin.test.ts
+++ b/packages/core/src/routes/auth/admin.test.ts
@@ -89,6 +89,8 @@ describe("admin auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(code).toBe(400);
     expect(body?.code).toBe("BAD_REQUEST");
@@ -120,6 +122,8 @@ describe("admin auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(code).toBe(204);
     expect(db.magicLink.create).toHaveBeenCalled();
@@ -155,6 +159,8 @@ describe("admin auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(code).toBe(200);
     expect(typeof body?.login_url).toBe("string");
@@ -179,6 +185,8 @@ describe("admin auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(code).toBe(204);
     expect(String(headers["Set-Cookie"]).includes("Max-Age=0")).toBe(true);
@@ -204,6 +212,8 @@ describe("admin auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(code).toBe(400);
     expect(body?.code).toBe("BAD_REQUEST");
@@ -230,6 +240,8 @@ describe("admin auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(code).toBe(401);
     expect(body?.code).toBe("INVALID_TOKEN");
@@ -276,6 +288,8 @@ describe("admin auth routes", () => {
       redirect(url: string, status?: number) {
         redirected = [url, status];
       },
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(code).toBe(0); // redirect path, no json
     expect(redirected[0]).toBe("https://admin");
@@ -309,6 +323,8 @@ describe("admin auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(code).toBe(204);
   });
@@ -350,6 +366,8 @@ describe("admin auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
 
     expect(code).toBe(204);
@@ -374,6 +392,8 @@ describe("admin auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(code).toBe(401);
     expect(body?.code).toBe("UNAUTHORIZED");
@@ -405,6 +425,8 @@ describe("admin auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(code).toBe(200);
     expect(body?.user?.email).toBe("a@b.co");
@@ -437,6 +459,8 @@ describe("admin auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(code).toBe(200);
     expect(body?.kind).toBe("admin");
@@ -479,6 +503,8 @@ describe("admin auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(code).toBe(200);
     expect(Array.isArray(body?.items)).toBe(true);
@@ -510,6 +536,8 @@ describe("admin auth routes", () => {
           return this as any;
         },
         redirect() {},
+        sendStream() {},
+        sendBuffer() {},
       },
     );
     expect(code).toBe(204);

--- a/packages/core/src/routes/auth/cli.test.ts
+++ b/packages/core/src/routes/auth/cli.test.ts
@@ -119,6 +119,8 @@ describe("cli auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(200);
     expect(body?.device_code).toBeTruthy();
@@ -142,6 +144,8 @@ describe("cli auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(400);
     expect(body?.code).toBe("BAD_REQUEST");
@@ -176,6 +180,8 @@ describe("cli auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(200);
     expect(body?.verification_uri?.startsWith("https://admin.local/cli/device/approve")).toBe(true);
@@ -198,6 +204,8 @@ describe("cli auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(400);
     expect(body?.code).toBe("BAD_REQUEST");
@@ -248,6 +256,8 @@ describe("cli auth routes", () => {
           return res;
         },
         redirect() {},
+        sendStream() {},
+        sendBuffer() {},
       };
       return {
         res,
@@ -317,6 +327,8 @@ describe("cli auth routes", () => {
           return this as any;
         },
         redirect() {},
+        sendStream() {},
+        sendBuffer() {},
       });
       return { status, payload };
     }
@@ -406,6 +418,8 @@ describe("cli auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(200);
     expect(Array.isArray(body?.tokens)).toBe(true);
@@ -428,6 +442,8 @@ describe("cli auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(400);
     expect(body?.code).toBe("BAD_REQUEST");
@@ -446,6 +462,8 @@ describe("cli auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(204);
   });
@@ -479,6 +497,8 @@ describe("cli auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(201);
     expect(body?.token?.startsWith("lfk_")).toBe(true);
@@ -519,6 +539,8 @@ describe("cli auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(201);
     expect(body?.token?.startsWith("lfk_")).toBe(true);

--- a/packages/core/src/routes/auth/recipient.test.ts
+++ b/packages/core/src/routes/auth/recipient.test.ts
@@ -56,6 +56,8 @@ describe("recipient auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(404);
     expect((body as any)?.code).toBe("NOT_FOUND");
@@ -77,6 +79,8 @@ describe("recipient auth routes", () => {
             return this as any;
           },
           redirect() {},
+          sendStream() {},
+          sendBuffer() {},
         } as any,
       );
     }
@@ -119,6 +123,8 @@ describe("recipient auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(400);
     expect(body?.code).toBe("BAD_REQUEST");
@@ -139,6 +145,8 @@ describe("recipient auth routes", () => {
             return this as any;
           },
           redirect() {},
+          sendStream() {},
+          sendBuffer() {},
         } as any,
       );
     }
@@ -188,6 +196,8 @@ describe("recipient auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(code).toBe(204);
 
@@ -229,6 +239,8 @@ describe("recipient auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(204);
     expect(String(headers["Set-Cookie"]).includes("Max-Age=0")).toBe(true);
@@ -250,6 +262,8 @@ describe("recipient auth routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(204);
     expect(String(headers["Set-Cookie"]).includes("Max-Age=0")).toBe(true);

--- a/packages/core/src/routes/health.test.ts
+++ b/packages/core/src/routes/health.test.ts
@@ -24,6 +24,8 @@ describe("health routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(200);
     expect(json).toEqual({ status: "ok", queue: "memory", storage: "fs" });
@@ -49,6 +51,8 @@ describe("health routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(200);
   });
@@ -82,6 +86,8 @@ describe("health routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(200);
     expect(json?.status).toBe("ready");
@@ -117,6 +123,8 @@ describe("health routes", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
     expect(status).toBe(503);
     expect(body?.code).toBe("NOT_READY");

--- a/packages/core/src/routes/openapi.test.ts
+++ b/packages/core/src/routes/openapi.test.ts
@@ -45,6 +45,8 @@ describe("openapi route", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
 
     expect(status).toBe(200);
@@ -71,6 +73,8 @@ describe("openapi route", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
 
     expect(status).toBe(404);
@@ -104,6 +108,8 @@ describe("openapi route", () => {
         return this as any;
       },
       redirect() {},
+      sendStream() {},
+      sendBuffer() {},
     });
 
     expect(status).toBe(500);

--- a/packages/core/src/test/prisma-mock.ts
+++ b/packages/core/src/test/prisma-mock.ts
@@ -33,4 +33,5 @@ export const prisma = {
   changeLog: mkModel(),
   plugin: mkModel(),
   pluginCapability: mkModel(),
+  file: mkModel(),
 };

--- a/packages/core/tests/files.integration.test.ts
+++ b/packages/core/tests/files.integration.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import type { HttpHandler } from "../src/http/http-server.js";
+import { createMemoryStorage } from "../src/storage/memory.js";
+import { createStorageService } from "../src/storage/service.js";
+
+// Minimal DB mock wired via getDb() mock
+const db = {
+  file: {
+    findMany: vi.fn(async (): Promise<any[]> => []),
+    findUnique: vi.fn(async (): Promise<any> => null),
+    create: vi.fn(async (): Promise<any> => ({})),
+    update: vi.fn(async (): Promise<any> => ({})),
+    deleteMany: vi.fn(async (): Promise<any> => ({})),
+  },
+  apiToken: { findUnique: vi.fn(async (): Promise<any> => null), update: vi.fn(async () => ({})) },
+  user: { findUnique: vi.fn(async (): Promise<any> => null) },
+};
+vi.mock("../src/db/db.js", () => ({ getDb: () => db }));
+
+// Admin session shortcut
+vi.mock("../src/middleware/require-session.js", () => ({
+  requireSession: vi.fn(async () => ({ user: { id: "u1", role: "ADMIN", isActive: true } })),
+}));
+
+let storageSvc: ReturnType<typeof createStorageService>;
+
+async function makeServer() {
+  const handlers = new Map<string, HttpHandler>();
+  const server = {
+    get: (p: string, h: HttpHandler) => handlers.set(`GET ${p}`, h),
+    post: (p: string, h: HttpHandler) => handlers.set(`POST ${p}`, h),
+    delete: (p: string, h: HttpHandler) => handlers.set(`DELETE ${p}`, h),
+  } as any;
+  const { registerFileAdminRoutes } = await import("../src/routes/admin/files.js");
+  registerFileAdminRoutes(server, { storage: storageSvc } as any);
+  return { handlers };
+}
+
+function resCapture() {
+  let status = 0;
+  let body: any = null;
+  const headers: Record<string, string | string[]> = {};
+  let streamCalled: { headers: Record<string, string | string[]>; stream?: any } | null = null;
+  const res = {
+    status(c: number) {
+      status = c;
+      return this as any;
+    },
+    json(p: any) {
+      body = p;
+    },
+    header(name: string, value: any) {
+      headers[name] = value;
+      return this as any;
+    },
+    redirect() {},
+    sendStream(s: any, h?: any) {
+      streamCalled = { headers: h ?? {}, stream: s };
+    },
+    sendBuffer() {},
+  } as any;
+  return {
+    res,
+    get status() {
+      return status;
+    },
+    get body() {
+      return body;
+    },
+    get headers() {
+      return headers;
+    },
+    get stream() {
+      return streamCalled;
+    },
+  };
+}
+
+describe("files integration (in-package)", () => {
+  beforeAll(async () => {
+    const driver = await createMemoryStorage({ config: null } as any);
+    storageSvc = createStorageService({ driver, bucket: "b", keyPrefix: "p" } as any);
+  });
+
+  it("upload → list → download → delete", async () => {
+    const state: any[] = [];
+    // In-memory behavior for this test only
+    (db.file.create as any).mockImplementationOnce(async ({ data, select }: any) => {
+      const row = {
+        id: "f-int-1",
+        key: data.key,
+        size: data.size,
+        contentType: data.contentType,
+        metadata: data.metadata ?? null,
+        contentHash: data.contentHash,
+        storageKey: data.storageKey,
+        updatedAt: new Date().toISOString(),
+      };
+      state.push(row);
+      return Object.fromEntries(Object.keys(select).map((k) => [k, (row as any)[k]]));
+    });
+    (db.file.findMany as any).mockImplementation(async ({ select }: any) => {
+      return state.map((r) =>
+        Object.fromEntries(Object.keys(select).map((k) => [k, (r as any)[k]])),
+      );
+    });
+    (db.file.findUnique as any).mockImplementation(async ({ where, select }: any) => {
+      const r = state.find((x) => x.id === where.id);
+      if (!r) return null;
+      return Object.fromEntries(Object.keys(select).map((k) => [k, (r as any)[k]]));
+    });
+    (db.file.deleteMany as any).mockImplementationOnce(async ({ where }: any) => {
+      const id = where.id;
+      const idx = state.findIndex((x) => x.id === id);
+      if (idx >= 0) state.splice(idx, 1);
+      return {};
+    });
+
+    const { handlers } = await makeServer();
+
+    // 1) upload
+    const hUpload = handlers.get("POST /files/upload")!;
+    const rcUp = resCapture();
+    await hUpload(
+      {
+        headers: { "content-type": "multipart/form-data" },
+        body: { key: "int/file.txt", metadata: { i: "1" } },
+        file: {
+          buffer: Buffer.from("integration-bytes"),
+          originalname: "file.txt",
+          mimetype: "text/plain",
+          size: 18,
+        },
+      } as any,
+      rcUp.res,
+    );
+    expect(rcUp.status).toBe(201);
+    const etag = rcUp.headers["ETag"] as string;
+    expect(typeof etag).toBe("string");
+
+    // 2) list
+    const hList = handlers.get("GET /files")!;
+    const rcList = resCapture();
+    await hList({ headers: {} } as any, rcList.res);
+    expect(rcList.status).toBe(200);
+    expect(rcList.body?.items?.length).toBeGreaterThan(0);
+
+    // 3) download
+    const hGet = handlers.get("GET /files/:id")!;
+    const rcMeta = resCapture();
+    await hGet({ headers: {}, params: { id: "f-int-1" } } as any, rcMeta.res);
+    expect(rcMeta.status).toBe(200);
+    const hDl = handlers.get("GET /files/:id/download")!;
+    const rcDl = resCapture();
+    await hDl({ headers: {}, params: { id: "f-int-1" } } as any, rcDl.res);
+    expect(rcDl.stream).toBeTruthy();
+    expect(rcDl.stream?.headers?.["ETag"]).toBe(etag);
+    const chunks: Buffer[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const s: any = rcDl.stream?.stream;
+      s.on("data", (c: Buffer) => chunks.push(Buffer.from(c)));
+      s.on("end", resolve);
+      s.on("error", reject);
+    });
+    expect(Buffer.concat(chunks).toString("utf8")).toBe("integration-bytes");
+
+    // 4) delete
+    const hDel = handlers.get("DELETE /files/:id")!;
+    const rcDel = resCapture();
+    await hDel({ headers: {}, params: { id: "f-int-1" } } as any, rcDel.res);
+    expect(rcDel.status).toBe(204);
+
+    // 5) confirm list no longer includes the item
+    const rcList2 = resCapture();
+    await hList({ headers: {} } as any, rcList2.res);
+    expect(rcList2.status).toBe(200);
+    const hasItem =
+      Array.isArray(rcList2.body?.items) &&
+      rcList2.body.items.some((it: any) => it.id === "f-int-1");
+    expect(hasItem).toBe(false);
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -5,12 +5,7 @@ import path from "node:path";
 export default defineConfig({
   resolve: {
     alias: [
-      // Allow legacy test imports like "../../src/..." to resolve to the workspace src folder
-      {
-        find: /^\.\.\/\.\.\/src\//,
-        replacement: path.join(fileURLToPath(new URL("./", import.meta.url)), "src/"),
-      },
-      // Redirect Prisma client to a local mock for tests to avoid resolving the real package
+      // Ensure @latchflow/db resolves to the Core test Prisma mock when running package tests
       {
         find: /^@latchflow\/db$/,
         replacement: path.join(
@@ -21,16 +16,7 @@ export default defineConfig({
     ],
   },
   test: {
-    include: [
-      // Colocated unit tests alongside source files
-      "src/**/*.test.ts",
-      "src/**/*.spec.ts",
-    ],
-    setupFiles: ["./src/test/setup.ts"],
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "html", "lcov"],
-      reportsDirectory: "./coverage",
-    },
+    include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
+    setupFiles: [path.join(fileURLToPath(new URL("./", import.meta.url)), "src/test/setup.ts")],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       helmet:
         specifier: ^7.1.0
         version: 7.2.0
+      multer:
+        specifier: ^2.0.2
+        version: 2.0.2
       pino:
         specifier: ^9.3.2
         version: 9.8.0
@@ -94,6 +97,9 @@ importers:
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.23
+      '@types/multer':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@types/node':
         specifier: ^20.11.0
         version: 20.19.9
@@ -1153,6 +1159,9 @@ packages:
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
+  '@types/multer@2.0.0':
+    resolution: {integrity: sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw==}
+
   '@types/node@20.19.9':
     resolution: {integrity: sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==}
 
@@ -1364,6 +1373,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  append-field@1.0.0:
+    resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -1440,6 +1452,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.18'
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -2610,6 +2626,10 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
 
@@ -2657,6 +2677,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  multer@2.0.2:
+    resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
+    engines: {node: '>= 10.16.0'}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -3380,6 +3404,10 @@ packages:
   stickyfill@1.1.1:
     resolution: {integrity: sha512-GCp7vHAfpao+Qh/3Flh9DXEJ/qSi0KJwJw6zYlZOtRYXWUIpMM6mC2rIep/dK8RQqwW0KxGJIllmjPIBOGN8AA==}
 
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
@@ -3815,6 +3843,10 @@ packages:
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -4797,6 +4829,10 @@ snapshots:
 
   '@types/minimist@1.2.5': {}
 
+  '@types/multer@2.0.0':
+    dependencies:
+      '@types/express': 4.17.23
+
   '@types/node@20.19.9':
     dependencies:
       undici-types: 6.21.0
@@ -4957,14 +4993,14 @@ snapshots:
       chai: 5.3.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(msw@2.10.5(@types/node@20.19.9)(typescript@5.9.2))(vite@5.4.19(@types/node@24.2.0))':
+  '@vitest/mocker@2.1.9(msw@2.10.5(@types/node@20.19.9)(typescript@5.9.2))(vite@5.4.19(@types/node@20.19.9))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.10.5(@types/node@20.19.9)(typescript@5.9.2)
-      vite: 5.4.19(@types/node@24.2.0)
+      vite: 5.4.19(@types/node@20.19.9)
 
   '@vitest/mocker@2.1.9(msw@2.10.5(@types/node@24.2.0)(typescript@5.9.2))(vite@5.4.19(@types/node@24.2.0))':
     dependencies:
@@ -5069,6 +5105,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  append-field@1.0.0: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -5149,6 +5187,10 @@ snapshots:
     dependencies:
       esbuild: 0.25.8
       load-tsconfig: 0.2.5
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
 
   bytes@3.1.2: {}
 
@@ -6341,6 +6383,10 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
+
   mlly@1.7.4:
     dependencies:
       acorn: 8.15.0
@@ -6420,6 +6466,16 @@ snapshots:
       typescript: 5.9.2
     transitivePeerDependencies:
       - '@types/node'
+
+  multer@2.0.2:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 2.0.0
+      mkdirp: 0.5.6
+      object-assign: 4.1.1
+      type-is: 1.6.18
+      xtend: 4.0.2
 
   mute-stream@2.0.0: {}
 
@@ -7214,6 +7270,8 @@ snapshots:
 
   stickyfill@1.1.1: {}
 
+  streamsearch@1.1.0: {}
+
   strict-event-emitter@0.5.1: {}
 
   string-argv@0.3.2: {}
@@ -7559,7 +7617,7 @@ snapshots:
   vitest@2.1.9(@types/node@20.19.9)(msw@2.10.5(@types/node@20.19.9)(typescript@5.9.2)):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(msw@2.10.5(@types/node@20.19.9)(typescript@5.9.2))(vite@5.4.19(@types/node@24.2.0))
+      '@vitest/mocker': 2.1.9(msw@2.10.5(@types/node@20.19.9)(typescript@5.9.2))(vite@5.4.19(@types/node@20.19.9))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -7691,6 +7749,8 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.0
+
+  xtend@4.0.2: {}
 
   y18n@4.0.3: {}
 


### PR DESCRIPTION
## **Summary**

Implement the `/files` endpoints in the Core service. These endpoints handle storage and management of file objects, including upload, listing, retrieval, metadata updates, deletion, and download. This provides the foundation for bundle management and recipient delivery.

## **Scope**

- Add Express routes under `src/routes/admin/files/*.ts` (or a single `src/routes/admin/files.ts` that registers all file routes).
- Unit test the route source file(s) (`src/routes/admin/files*.test.ts`).
- Add file-level helpers to `storage/service.ts` for non-bundle objects:
    - `putFile({ body, contentType })` → returns `{ storageKey, size, etag }`
    - `getFileStream(storageKey)` / `headFile(storageKey)` / `deleteFile(storageKey)`
    - Content-addressed storageKey strategy (e.g., `objects/sha256/ab/cd/<hash>`)
- Implement streaming support in HTTP layer:
    - Add `sendStream` (and `sendBuffer`) to `ResponseLike` and wire through `express-server.ts`.
    - Use `sendStream` in download route with `Content-Type`, `Content-Length` (when known), and `ETag` headers.
- Ensure Prisma `File` model is used consistently; implement a DTO mapper converting `BigInt` → `number` and deriving `etag` from `contentHash`.
- Enforce auth with AuthZ policy and scopes (`files:read`, `files:write`) via `requireAdminOrApiToken`.
- Cover single and batch operations, including metadata patching and logical move/rename (`key` only, not `storageKey`).
- Ensure file streaming and ETag headers work for downloads.
- Clarify auditing: `DownloadEvent` is only for recipient downloads; admin downloads are captured via decision logs.

## **To-Do**

- [x]  Implement streaming support: extend `ResponseLike` with `sendStream` and update `express-server.ts` adapter to pipe streams and set headers.
    - [x]  HTTP layer streaming support:
        - [x]  Update `packages/core/src/http/http-server.ts` to add to `ResponseLike`:
            - [x]  `sendStream(body: NodeJS.ReadableStream, headers?: Record<string, string | string[]>)`
            - [x]  `sendBuffer(body: Buffer, headers?: Record<string, string | string[]>)`
        - [x]  Implement these in `packages/core/src/http/express-server.ts`:
            - [x]  Set provided headers before sending; support string and string[] values.
            - [x]  Pipe the readable to the Express response without buffering; handle `error` on the stream by aborting the response with a 500 if headers not sent.
            - [x]  If a `Content-Length` is provided in headers, do not chunk-transform; otherwise default chunked transfer is fine.
            - [x]  Ensure backpressure is respected (use native piping) and resources are cleaned up on client abort (listen for `req`/`res` `close` events and destroy the source stream).
        - [x]  Tests in `packages/core/src/http/express-server.test.ts`:
            - [x]  Happy path: returns exact bytes from a Readable and sets `Content-Type` and `ETag` headers.
            - [x]  Error propagation: stream emits `error` → 500 JSON error when headers not yet sent.
            - [x]  Idempotent completion: stream `end` closes response; no extra writes occur.
            - [ ]  Optional: when `Content-Length` header is provided, client sees the same length.
- [x]  Add file-level helpers in `storage/service.ts`:
    - [x]  `putFile(args: { body: Buffer | Readable; contentType?: string })` → computes SHA-256 over the stream, builds a content‑addressed `storageKey` like `objects/sha256/aa/bb/<hash>`, writes via `driver.put`, and returns `{ storageKey, size, etag: <sha256> }`.
    - [x]  `getFileStream(storageKey: string)` → fetches readable stream via `driver.getStream`.
    - [x]  `headFile(storageKey: string)` → returns `{ size, contentType?, metadata? }` via `driver.head`.
    - [x]  `deleteFile(storageKey: string)` → deletes via `driver.del` (idempotent; ignore not found).
    - [x]  Respect `keyPrefix` for all paths; do not alter bucket.
    - [x]  Internal helper: `sha256HexFrom(body: Buffer|Readable)` for streaming hash.
    - [x]  Tests for file-level helpers (extend `packages/core/src/storage/service.test.ts`):
        - [x]  Put/get/head/delete happy path using the memory driver; verify returned `storageKey` shape matches `objects/sha256/aa/bb/<hash>` and `etag` equals the computed SHA-256.
        - [x]  `contentType` is persisted (fs driver uses `.ct` sidecar); `headFile` reflects it when provided to `putFile`.
        - [x]  Duplicate uploads of identical content produce the same `storageKey` (idempotent content addressing) and consistent `size`/`etag`.
        - [x]  `getFileStream` returns a readable whose bytes match the uploaded content.
        - [x]  `deleteFile` succeeds and becomes idempotent (second delete does not throw).
        - [x]  Prefix handling: when `keyPrefix` is set in service, resulting storage paths include the prefix before `objects/...`.
- [x]  Add DTO mapper (`toFileDto`) to serialize `File` safely (BigInt → number, `etag` from `contentHash`).
- [x]  Define route modules for:
    - [x]  `GET /files` (list files, pagination, query filters)
    - [x]  `POST /files/upload` (multipart upload with `multer`)
    - [x]  `POST /files/upload-url` (generate presigned upload URL) — see "Presigned uploads" note below
    - [x]  `GET /files/{id}` (get file metadata)
    - [x]  `DELETE /files/{id}` (delete file)
    - [x]  `POST /files/{id}/move` (rename key)
    - [x]  `PATCH /files/{id}/metadata` (update metadata)
    - [x]  `POST /files/batch/delete` (delete multiple files)
    - [x]  `POST /files/batch/move` (move multiple files)
    - [x]  `GET /files/{id}/download` (stream file to client)
- [x]  Add Prisma queries to persist file records (`@latchflow/db`).
- [x]  Handle validation and error responses (use `http/validate.ts`).
- [x]  Ensure audit hooks/logging are in place for downloads (decision logs for admin; no `DownloadEvent`).
- [x]  Add unit tests for each route (memory storage driver) including streaming and headers.
- [x]  Add integration test: upload → list → download → delete.
- [x]  Register the file routes from `src/index.ts`.
- [x]  Update test Prisma mock to include a `file` model with the methods used by routes.
- [x]  Add/extend AuthZ policies and scopes for all `/files` routes and enforce with `requireAdminOrApiToken`.
- [x]  Pagination and filters:
    - [x]  Cursor pagination with `limit` and `cursor`.
    - [x]  `prefix` filter on `key` (startsWith), `q` full-text-ish (key contains), and `unassigned` (files with `bundleObjects: { none: {} }`).

### **Presigned uploads**

- [x]  For this PR: stub `POST /files/upload-url` returning `501 Not Implemented` unless a driver advertises support (future extension), to keep the API shape but defer implementation.
- [ ]  Follow-up (future PR): extend `StorageDriver` with optional `createSignedPutUrl`/`createSignedPostUrl` and add a finalize/commit endpoint to persist `File` after the client uploads directly to storage.

### **ETag/contentHash**

- [x]  Compute `sha256` hash on direct uploads and store in `File.contentHash` (derive `etag` from this value).
- [x]  Set `ETag` header on `201 Created` and on `GET /files/{id}/download` responses.
- [ ]  Use `contentHash` for deduplication in the future (out of scope for this PR).

### **AuthZ & Scopes**

- [x]  Add policy entries in `src/authz/policy.ts` for every `/files` route using a `resource: "file"` and appropriate actions (`read`, `write`, `delete`, `manage`).
- [x]  Guard routes with `requireAdminOrApiToken({ scopes: [FILES_READ/FILES_WRITE] })` as appropriate.

### **Batch operations & atomicity**

- [x]  For delete: perform storage deletion first, then DB delete inside a Prisma transaction; best-effort revert storage on DB failure; idempotent on missing storage objects.
- [x]  For move: update logical `key` only in DB (not `storageKey`), transactionally; validate uniqueness.
- [x]  For metadata patch: shallow-merge/replace per API design and validate keys.

## **DoD**

- [x]  All `/files` routes match OpenAPI spec (request/response schemas).
- [x]  File upload works via direct multipart. Presigned upload endpoint exists but may return `501` unless supported by the storage driver (tracked for a follow-up PR).
- [x]  Metadata and move endpoints update records and storage consistently.
- [x]  Batch operations follow the pragmatic atomicity strategy (storage-first, Prisma transaction, best-effort revert) and are idempotent on retriable errors.
- [x]  File downloads stream correctly with `ETag` and correct `Content-Type`.
- [x]  Unauthorized requests are rejected correctly.
- [x]  Tests pass locally with `pnpm core:test`.
- [x]  Admin downloads are recorded via decision logs; `DownloadEvent` is reserved for recipient-initiated downloads.
- [x]  Documentation updated (`README.md` or `docs/ROADMAP.md`) with usage examples and notes about presigned uploads being deferred.