### PR TITLE
Recipient + Portal Flows

### DIFF
--- a/packages/core/openapi/paths/auth/recipient.yaml
+++ b/packages/core/openapi/paths/auth/recipient.yaml
@@ -8,18 +8,22 @@ recipient_start:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              recipientId:
-                type: string
-              bundleId:
-                type: string
-            required: [recipientId, bundleId]
+            oneOf:
+              - type: object
+                properties:
+                  recipientId: { type: string }
+                required: [recipientId]
+              - type: object
+                properties:
+                  email: { type: string, format: email }
+                required: [email]
           examples:
-            example:
+            "recipient ID":
               value:
                 recipientId: 11111111-1111-1111-1111-111111111111
-                bundleId: 22222222-2222-2222-2222-222222222222
+            email:
+              value:
+                email: recipient@example.com
     responses:
       '204':
         description: OTP issued (dev logs only)
@@ -40,20 +44,28 @@ recipient_verify:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              recipientId:
-                type: string
-              bundleId:
-                type: string
-              otp:
-                type: string
-            required: [recipientId, bundleId, otp]
+            allOf:
+              - oneOf:
+                  - type: object
+                    properties:
+                      recipientId: { type: string }
+                    required: [recipientId]
+                  - type: object
+                    properties:
+                      email: { type: string, format: email }
+                    required: [email]
+              - type: object
+                properties:
+                  otp: { type: string }
+                required: [otp]
           examples:
             example:
               value:
                 recipientId: 11111111-1111-1111-1111-111111111111
-                bundleId: 22222222-2222-2222-2222-222222222222
+                otp: "123456"
+            example_by_email:
+              value:
+                email: recipient@example.com
                 otp: "123456"
     responses:
       '204':

--- a/packages/core/openapi/paths/portal.yaml
+++ b/packages/core/openapi/paths/portal.yaml
@@ -110,11 +110,15 @@ portal_otp_resend:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              recipientId: { type: string, format: uuid }
-              bundleId: { type: string, format: uuid }
-            required: [recipientId, bundleId]
+            oneOf:
+              - type: object
+                properties:
+                  recipientId: { type: string, format: uuid }
+                required: [recipientId]
+              - type: object
+                properties:
+                  email: { type: string, format: email }
+                required: [email]
     responses:
       '204': { description: Sent }
       '429': { $ref: ../components/responses/RateLimited.yaml }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ import {
 import { loadStorage } from "./storage/loader.js";
 import { createStorageService } from "./storage/service.js";
 import { registerOpenApiRoute } from "./routes/openapi.js";
+import { registerPortalRoutes } from "./routes/portal.js";
 import { registerPluginRoutes } from "./routes/admin/plugins.js";
 import { registerFileAdminRoutes } from "./routes/admin/files.js";
 
@@ -102,6 +103,7 @@ export async function main() {
   registerHealthRoutes(server, { queueName, storageName, checkDb, checkQueue, checkStorage });
   registerAdminAuthRoutes(server, config);
   registerRecipientAuthRoutes(server, config);
+  registerPortalRoutes(server, { storage: _storageService });
   registerCliAuthRoutes(server, config);
   registerPluginRoutes(server);
   registerFileAdminRoutes(server, { storage: _storageService });

--- a/packages/core/src/middleware/require-recipient.test.ts
+++ b/packages/core/src/middleware/require-recipient.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, vi } from "vitest";
 
 vi.mock("../db/db.js", () => {
   const recipientSession = { findUnique: vi.fn() };
-  return { getDb: () => ({ recipientSession }), __rs: recipientSession } as any;
+  const recipient = { findUnique: vi.fn() };
+  const bundleAssignment = { findFirst: vi.fn() };
+  return {
+    getDb: () => ({ recipientSession, recipient, bundleAssignment }),
+    __rs: recipientSession,
+    __r: recipient,
+    __ba: bundleAssignment,
+  } as any;
 });
 
 describe("requireRecipient", () => {
@@ -12,30 +19,35 @@ describe("requireRecipient", () => {
     await expect(requireRecipient(req)).rejects.toMatchObject({ status: 401 });
   });
 
-  it("rejects when bundle mismatch in scoped route", async () => {
+  it("rejects when no assignment for bundle in scoped route", async () => {
     const mod = await import("../db/db.js");
     (mod as any).__rs.findUnique.mockResolvedValueOnce({
       jti: "tok",
+      recipientId: "R1",
       revokedAt: null,
       expiresAt: new Date(Date.now() + 60000),
-      bundleId: "B1",
     });
+    (mod as any).__r.findUnique.mockResolvedValueOnce({ id: "R1", isEnabled: true });
+    (mod as any).__ba.findFirst.mockResolvedValueOnce(null);
     const { requireRecipient } = await import("../middleware/require-recipient.js");
     const req = { headers: { cookie: "lf_recipient_sess=tok" }, params: { bundleId: "B2" } } as any;
     await expect(requireRecipient(req, true)).rejects.toMatchObject({ status: 403 });
   });
 
-  it("returns session when valid", async () => {
+  it("returns session and assignment when valid for bundle", async () => {
     const mod = await import("../db/db.js");
     (mod as any).__rs.findUnique.mockResolvedValueOnce({
       jti: "tok",
+      recipientId: "R1",
       revokedAt: null,
       expiresAt: new Date(Date.now() + 60000),
-      bundleId: "B1",
     });
+    (mod as any).__r.findUnique.mockResolvedValueOnce({ id: "R1", isEnabled: true });
+    (mod as any).__ba.findFirst.mockResolvedValueOnce({ id: "A1" });
     const { requireRecipient } = await import("../middleware/require-recipient.js");
     const req = { headers: { cookie: "lf_recipient_sess=tok" }, params: { bundleId: "B1" } } as any;
     const out = await requireRecipient(req, true);
     expect(out.session.jti).toBe("tok");
+    expect(out.assignment.id).toBe("A1");
   });
 });

--- a/packages/core/src/middleware/require-recipient.ts
+++ b/packages/core/src/middleware/require-recipient.ts
@@ -9,6 +9,41 @@ function httpError(status: number, message: string) {
   return err;
 }
 
+// Minimal row shapes to avoid importing Prisma types
+type RecipientSessionRow = {
+  jti: string;
+  recipientId: string;
+  revokedAt: Date | null;
+  expiresAt: Date;
+};
+type RecipientRow = { id: string; isEnabled?: boolean };
+type BundleAssignmentRow = {
+  id: string;
+  bundleId: string;
+  recipientId: string;
+  isEnabled?: boolean;
+  verificationType?: string | null;
+  verificationMet?: boolean;
+  lastDownloadAt?: Date | null;
+  cooldownSeconds?: number | null;
+  maxDownloads?: number | null;
+};
+
+// Overloads encode return shape based on bundleScoped flag
+export async function requireRecipient(
+  req: RequestLike,
+  bundleScoped: true,
+  routeBundleId?: string,
+): Promise<{
+  session: RecipientSessionRow;
+  recipient: RecipientRow;
+  assignment: BundleAssignmentRow;
+}>;
+export async function requireRecipient(
+  req: RequestLike,
+  bundleScoped?: false,
+  routeBundleId?: string,
+): Promise<{ session: RecipientSessionRow; recipient: RecipientRow }>;
 export async function requireRecipient(
   req: RequestLike,
   bundleScoped = false,
@@ -19,12 +54,16 @@ export async function requireRecipient(
   if (!token) throw httpError(401, "Missing recipient session");
   const db = getDb();
   const now = new Date();
-  const session = await db.recipientSession.findUnique({ where: { jti: token } });
+  const session = (await db.recipientSession.findUnique({ where: { jti: token } })) as
+    | (RecipientSessionRow & Record<string, unknown>)
+    | null;
   if (!session || session.revokedAt || session.expiresAt <= now) {
     throw httpError(401, "Invalid or expired recipient session");
   }
   // Ensure recipient is enabled
-  const recipient = await db.recipient.findUnique({ where: { id: session.recipientId } });
+  const recipient = (await db.recipient.findUnique({ where: { id: session.recipientId } })) as
+    | (RecipientRow & Record<string, unknown>)
+    | null;
   if (!recipient || (recipient as { isEnabled?: boolean }).isEnabled === false) {
     throw httpError(403, "Recipient disabled or not found");
   }
@@ -35,7 +74,7 @@ export async function requireRecipient(
     if (!expected) {
       throw httpError(400, "Missing bundleId in route");
     }
-    const assignment = await db.bundleAssignment.findFirst({
+    const assignment = (await db.bundleAssignment.findFirst({
       where: {
         recipientId: session.recipientId,
         bundleId: expected,
@@ -43,7 +82,7 @@ export async function requireRecipient(
         recipient: { isEnabled: true },
         bundle: { isEnabled: true },
       },
-    });
+    })) as (BundleAssignmentRow & Record<string, unknown>) | null;
     if (!assignment) {
       throw httpError(403, "Recipient not authorized for this bundle");
     }

--- a/packages/core/src/routes/portal.ts
+++ b/packages/core/src/routes/portal.ts
@@ -1,0 +1,180 @@
+import type { HttpServer } from "../http/http-server.js";
+import { getDb } from "../db/db.js";
+import { requireRecipient } from "../middleware/require-recipient.js";
+import type { StorageService } from "../storage/service.js";
+
+export function registerPortalRoutes(server: HttpServer, deps: { storage: StorageService }) {
+  const db = getDb();
+
+  // GET /portal/me
+  server.get("/portal/me", async (req, res) => {
+    try {
+      const { session, recipient } = await requireRecipient(req, false);
+      const assignments = await db.bundleAssignment.findMany({
+        where: {
+          recipientId: session.recipientId,
+          isEnabled: true,
+          recipient: { isEnabled: true },
+          bundle: { isEnabled: true },
+        },
+        select: { bundle: { select: { id: true, name: true } } },
+      });
+      const bundles = assignments
+        .map((a) => a.bundle)
+        .filter((b): b is { id: string; name: string } => Boolean(b));
+      res.status(200).json({ recipient, bundles });
+    } catch (e) {
+      const err = e as Error & { status?: number };
+      res
+        .status(err.status ?? 401)
+        .json({ status: "error", code: "UNAUTHORIZED", message: err.message });
+    }
+  });
+
+  // GET /portal/bundles
+  server.get("/portal/bundles", async (req, res) => {
+    try {
+      const { session } = await requireRecipient(req, false);
+      const qp = (req.query ?? {}) as Record<string, string>;
+      const limit = Math.max(1, Math.min(100, Number(qp["limit"]) || 50));
+      const assignments = await db.bundleAssignment.findMany({
+        where: {
+          recipientId: session.recipientId,
+          isEnabled: true,
+          recipient: { isEnabled: true },
+          bundle: { isEnabled: true },
+        },
+        take: limit,
+        orderBy: { updatedAt: "desc" },
+        select: {
+          bundle: {
+            select: {
+              id: true,
+              name: true,
+              storagePath: true,
+              checksum: true,
+              description: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+        },
+      });
+      const items = assignments.map((a) => a.bundle).filter(Boolean);
+      res.status(200).json({ items });
+    } catch (e) {
+      const err = e as Error & { status?: number };
+      res
+        .status(err.status ?? 401)
+        .json({ status: "error", code: "UNAUTHORIZED", message: err.message });
+    }
+  });
+
+  // GET /portal/bundles/:bundleId/objects
+  server.get("/portal/bundles/:bundleId/objects", async (req, res) => {
+    try {
+      const { assignment } = await requireRecipient(req, true);
+      // assignment exists and is enabled; list enabled bundle objects
+      const objects = await db.bundleObject.findMany({
+        where: { bundleId: assignment.bundleId, isEnabled: true },
+        orderBy: { sortOrder: "asc" },
+        select: { file: true },
+      });
+      const items = objects.map((o) => o.file).filter(Boolean);
+      res.status(200).json({ items });
+    } catch (e) {
+      const err = e as Error & { status?: number };
+      res
+        .status(err.status ?? 401)
+        .json({ status: "error", code: "UNAUTHORIZED", message: err.message });
+    }
+  });
+
+  // GET /portal/bundles/:bundleId (download)
+  server.get("/portal/bundles/:bundleId", async (req, res) => {
+    try {
+      const { assignment } = await requireRecipient(req, true);
+      const now = new Date();
+      // Enforcement: verification
+      if (assignment.verificationType && !assignment.verificationMet) {
+        res
+          .status(403)
+          .json({
+            status: "error",
+            code: "VERIFICATION_REQUIRED",
+            message: "Verification required",
+          });
+        return;
+      }
+      // Enforcement: maxDownloads
+      const used = await db.downloadEvent.count({ where: { bundleAssignmentId: assignment.id } });
+      if (assignment.maxDownloads != null && used >= assignment.maxDownloads) {
+        res
+          .status(403)
+          .json({
+            status: "error",
+            code: "MAX_DOWNLOADS_EXCEEDED",
+            message: "Download limit reached",
+          });
+        return;
+      }
+      // Enforcement: cooldown
+      if (
+        assignment.cooldownSeconds != null &&
+        assignment.lastDownloadAt &&
+        assignment.lastDownloadAt.getTime() + assignment.cooldownSeconds * 1000 > now.getTime()
+      ) {
+        res
+          .status(429)
+          .json({
+            status: "error",
+            code: "COOLDOWN_ACTIVE",
+            message: "Please wait before next download",
+          });
+        return;
+      }
+
+      // Fetch bundle
+      const bundle = await db.bundle.findUnique({ where: { id: assignment.bundleId } });
+      if (!bundle || (bundle as { isEnabled?: boolean }).isEnabled === false) {
+        res.status(404).json({ status: "error", code: "NOT_FOUND", message: "Bundle not found" });
+        return;
+      }
+      if (!bundle.storagePath) {
+        res
+          .status(409)
+          .json({
+            status: "error",
+            code: "NO_STORAGE_PATH",
+            message: "Bundle storage not available",
+          });
+        return;
+      }
+
+      // Record download event & update assignment lastDownloadAt
+      await db.downloadEvent.create({
+        data: {
+          bundleAssignmentId: assignment.id,
+          downloadedAt: now,
+          ip: req.ip ?? "",
+          userAgent: req.userAgent ?? "",
+        },
+      });
+      await db.bundleAssignment.update({
+        where: { id: assignment.id },
+        data: { lastDownloadAt: now },
+      });
+
+      // Stream bundle archive
+      const headers: Record<string, string> = { "Content-Type": "application/octet-stream" };
+      if (bundle.checksum) headers["ETag"] = bundle.checksum;
+      const stream = await deps.storage.getFileStream(bundle.storagePath);
+      res.sendStream(stream, headers);
+    } catch (e) {
+      const err = e as Error & { status?: number };
+      res
+        .status(err.status ?? 401)
+        .json({ status: "error", code: "UNAUTHORIZED", message: err.message });
+    }
+  });
+}

--- a/packages/core/src/storage/service.ts
+++ b/packages/core/src/storage/service.ts
@@ -1,6 +1,6 @@
 import type { StorageDriver } from "./types.js";
 import { createHash } from "node:crypto";
-import { Readable } from "node:stream";
+// import { Readable } from "node:stream";
 import fs from "node:fs";
 
 export type StorageService = ReturnType<typeof createStorageService>;
@@ -90,7 +90,7 @@ export function createStorageService(deps: ServiceDeps) {
       const putRes = await deps.driver.put({
         bucket: deps.bucket,
         key: storageKey,
-        body: Readable.from(bodyBuf),
+        body: bodyBuf, // pass Buffer so S3 driver can set ContentLength
         contentType: args.contentType,
       });
       const size = putRes.size ?? bodyBuf.length;

--- a/packages/core/tests/e2e/portal.e2e.test.ts
+++ b/packages/core/tests/e2e/portal.e2e.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import type { HttpHandler, HttpServer, ResponseLike } from "../../src/http/http-server.js";
+import { loadStorage } from "../../src/storage/loader.js";
+import { createStorageService } from "../../src/storage/service.js";
+import { getEnv } from "@tests/helpers/containers";
+
+function makeServer() {
+  const handlers = new Map<string, HttpHandler>();
+  const server: HttpServer = {
+    get: (p, h) => {
+      handlers.set(`GET ${p}`, h);
+      return undefined as any;
+    },
+    post: (p, h) => {
+      handlers.set(`POST ${p}`, h);
+      return undefined as any;
+    },
+    put: (p, h) => {
+      handlers.set(`PUT ${p}`, h);
+      return undefined as any;
+    },
+    delete: (p, h) => {
+      handlers.set(`DELETE ${p}`, h);
+      return undefined as any;
+    },
+    use: () => undefined as any,
+    listen: async () => undefined as any,
+  } as unknown as HttpServer;
+  return { handlers, server };
+}
+
+function resCapture() {
+  let status = 0;
+  let body: any = null;
+  const headers: Record<string, string | string[]> = {};
+  let streamed = false;
+  const res: ResponseLike = {
+    status(c: number) {
+      status = c;
+      return this;
+    },
+    json(p: any) {
+      body = p;
+    },
+    header(name: string, value: any) {
+      headers[name] = value;
+      return this;
+    },
+    redirect() {},
+    sendStream() {
+      streamed = true;
+    },
+    sendBuffer() {},
+  };
+  return {
+    res,
+    get status() {
+      return status;
+    },
+    get body() {
+      return body;
+    },
+    headers,
+    get streamed() {
+      return streamed;
+    },
+  };
+}
+
+function futureDate(ms = 60_000) {
+  return new Date(Date.now() + ms);
+}
+
+describe("E2E: recipient portal", () => {
+  beforeAll(() => {
+    // Ensure containers env is initialized (DATABASE_URL set in e2e setup)
+    expect(getEnv().postgres.url).toBeTruthy();
+  });
+
+  it("serves /portal/me and streams bundle download with DownloadEvent", async () => {
+    const env = getEnv();
+    // Build storage service backed by MinIO
+    const s3conf = {
+      region: env.minio.region,
+      endpoint: env.minio.endpoint,
+      presignEndpoint: env.minio.presignEndpoint,
+      forcePathStyle: env.minio.forcePathStyle ?? true,
+      accessKeyId: env.minio.accessKeyId,
+      secretAccessKey: env.minio.secretAccessKey,
+      ensureBucket: true,
+    } as const;
+    const { storage } = await loadStorage("s3", null, s3conf);
+    const storageSvc = createStorageService({
+      driver: storage,
+      bucket: env.minio.bucket,
+      keyPrefix: "e2e",
+    });
+
+    const { handlers, server } = makeServer();
+    const { registerPortalRoutes } = await import("../../src/routes/portal.js");
+    registerPortalRoutes(server, { storage: storageSvc });
+
+    // Seed DB with user, file, bundle, recipient, assignment, and recipient session
+    const { prisma } = await import("@latchflow/db");
+    const admin = await prisma.user.upsert({
+      where: { email: "e2e.portal.admin@example.com" },
+      update: { role: "ADMIN" as any },
+      create: { email: "e2e.portal.admin@example.com", role: "ADMIN" as any },
+    });
+
+    // Upload file and create File record
+    const put = await storageSvc.putFile({
+      body: Buffer.from("bundle-bytes"),
+      contentType: "application/octet-stream",
+    });
+    const file = await prisma.file.create({
+      data: {
+        key: "e2e/objects/bundle.bin",
+        storageKey: put.storageKey,
+        contentHash: put.sha256,
+        etag: put.storageEtag,
+        size: BigInt(put.size),
+        contentType: "application/octet-stream",
+        createdBy: admin.id,
+      },
+    });
+
+    // Create bundle with storagePath referencing the uploaded object
+    const bundle = await prisma.bundle.create({
+      data: {
+        name: "E2E Bundle",
+        storagePath: put.storageKey,
+        checksum: put.sha256,
+        description: "",
+        createdBy: admin.id,
+      },
+    });
+
+    await prisma.bundleObject.create({
+      data: {
+        bundleId: bundle.id,
+        fileId: file.id,
+        sortOrder: 0,
+        required: false,
+        createdBy: admin.id,
+      },
+    });
+
+    const recipient = await prisma.recipient.create({
+      data: { email: "e2e.recipient@example.com", createdBy: admin.id },
+    });
+    await prisma.bundleAssignment.create({
+      data: {
+        bundleId: bundle.id,
+        recipientId: recipient.id,
+        isEnabled: true,
+        verificationType: null,
+        verificationMet: true,
+        createdBy: admin.id,
+      },
+    });
+    const session = await prisma.recipientSession.create({
+      data: {
+        recipientId: recipient.id,
+        jti: "sess-e2e-1",
+        expiresAt: futureDate(),
+        ip: "127.0.0.1",
+      },
+    });
+    expect(session.jti).toBe("sess-e2e-1");
+
+    // 1) GET /portal/me
+    const hMe = handlers.get("GET /portal/me")!;
+    const rcMe = resCapture();
+    await hMe({ headers: { cookie: "lf_recipient_sess=sess-e2e-1" } } as any, rcMe.res);
+    expect(rcMe.status).toBe(200);
+    expect(rcMe.body?.recipient?.id).toBe(recipient.id);
+    expect(Array.isArray(rcMe.body?.bundles)).toBe(true);
+
+    // 2) GET /portal/bundles/:bundleId (stream)
+    const hDl = handlers.get("GET /portal/bundles/:bundleId")!;
+    const rcDl = resCapture();
+    await hDl(
+      {
+        headers: { cookie: "lf_recipient_sess=sess-e2e-1" },
+        params: { bundleId: bundle.id },
+      } as any,
+      rcDl.res,
+    );
+    expect(rcDl.streamed).toBe(true);
+
+    // 3) Verify DownloadEvent recorded
+    const events = await prisma.downloadEvent.count({
+      where: { bundleAssignment: { bundleId: bundle.id, recipientId: recipient.id } },
+    });
+    expect(events).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/tests/integration/portal.test.ts
+++ b/packages/core/tests/integration/portal.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { HttpHandler } from "../../src/http/http-server.js";
+import { Readable } from "node:stream";
+
+// Prisma-like mock
+const db = {
+  recipientSession: { findUnique: vi.fn(async (): Promise<any> => null) },
+  recipient: { findUnique: vi.fn(async (): Promise<any> => null) },
+  bundleAssignment: {
+    findMany: vi.fn(async (): Promise<any[]> => []),
+    findFirst: vi.fn(async (): Promise<any | null> => null),
+    update: vi.fn(async (): Promise<any> => ({})),
+  },
+  bundleObject: { findMany: vi.fn(async (): Promise<any[]> => []) },
+  bundle: { findUnique: vi.fn(async (): Promise<any | null> => null) },
+  downloadEvent: {
+    create: vi.fn(async (): Promise<any> => ({})),
+    count: vi.fn(async (): Promise<number> => 0),
+  },
+};
+
+vi.mock("../../src/db/db.js", () => ({ getDb: () => db }));
+
+function makeServer() {
+  const handlers = new Map<string, HttpHandler>();
+  const storage = {
+    getFileStream: vi.fn(async () => Readable.from(Buffer.from("ok"))),
+  } as any;
+  return { handlers, storage };
+}
+
+function futureDate(ms = 60_000) {
+  return new Date(Date.now() + ms);
+}
+
+describe("portal routes (integration)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    for (const model of Object.values(db) as any[]) {
+      for (const fn of Object.values(model) as any[]) {
+        if (typeof fn?.mockReset === "function") fn.mockReset();
+      }
+    }
+  });
+
+  it("GET /portal/me returns recipient and bundles", async () => {
+    const { handlers, storage } = makeServer();
+    const { registerPortalRoutes } = await import("../../src/routes/portal.js");
+    registerPortalRoutes({ get: serverGet } as any, { storage });
+
+    // register helper
+    function serverGet(path: string, h: HttpHandler) {
+      handlers.set(`GET ${path}`, h);
+    }
+
+    db.recipientSession.findUnique.mockResolvedValueOnce({
+      jti: "tok",
+      recipientId: "R1",
+      expiresAt: futureDate(),
+    });
+    db.recipient.findUnique.mockResolvedValueOnce({ id: "R1", isEnabled: true });
+    db.bundleAssignment.findMany.mockResolvedValueOnce([
+      { bundle: { id: "B1", name: "Bundle 1" } },
+      { bundle: { id: "B2", name: "Bundle 2" } },
+    ]);
+
+    const h = handlers.get("GET /portal/me")!;
+    let status = 0;
+    let body: any = null;
+    await h({ headers: { cookie: "lf_recipient_sess=tok" } } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json(p: any) {
+        body = p;
+      },
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(200);
+    expect(body?.recipient?.id).toBe("R1");
+    expect(body?.bundles?.length).toBe(2);
+  });
+
+  it("GET /portal/bundles returns items list", async () => {
+    const { handlers, storage } = makeServer();
+    const { registerPortalRoutes } = await import("../../src/routes/portal.js");
+    registerPortalRoutes({ get: serverGet } as any, { storage });
+    function serverGet(path: string, h: HttpHandler) {
+      handlers.set(`GET ${path}`, h);
+    }
+    db.recipientSession.findUnique.mockResolvedValueOnce({
+      jti: "tok",
+      recipientId: "R1",
+      expiresAt: futureDate(),
+    });
+    db.recipient.findUnique.mockResolvedValueOnce({ id: "R1", isEnabled: true });
+    db.bundleAssignment.findMany.mockResolvedValueOnce([
+      { bundle: { id: "B1", name: "Bundle 1" } },
+    ]);
+    const h = handlers.get("GET /portal/bundles")!;
+    let status = 0;
+    let body: any = null;
+    await h({ headers: { cookie: "lf_recipient_sess=tok" } } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json(p: any) {
+        body = p;
+      },
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(200);
+    expect(Array.isArray(body?.items)).toBe(true);
+    expect(body?.items?.[0]?.id).toBe("B1");
+    // Ensure we asked DB with isEnabled filters
+    const args = db.bundleAssignment.findMany.mock.calls[0]?.[0] ?? {};
+    expect(args?.where?.isEnabled).toBe(true);
+    expect(args?.where?.recipient?.isEnabled).toBe(true);
+    expect(args?.where?.bundle?.isEnabled).toBe(true);
+  });
+
+  it("GET /portal/bundles/:bundleId/objects lists files", async () => {
+    const { handlers, storage } = makeServer();
+    const { registerPortalRoutes } = await import("../../src/routes/portal.js");
+    registerPortalRoutes({ get: serverGet } as any, { storage });
+    function serverGet(path: string, h: HttpHandler) {
+      handlers.set(`GET ${path}`, h);
+    }
+    db.recipientSession.findUnique.mockResolvedValueOnce({
+      jti: "tok",
+      recipientId: "R1",
+      expiresAt: futureDate(),
+    });
+    db.recipient.findUnique.mockResolvedValueOnce({ id: "R1", isEnabled: true });
+    db.bundleAssignment.findFirst.mockResolvedValueOnce({
+      id: "A1",
+      bundleId: "B1",
+      recipientId: "R1",
+      isEnabled: true,
+    });
+    db.bundleObject.findMany.mockResolvedValueOnce([
+      { file: { id: "F1", key: "k1" } },
+      { file: { id: "F2", key: "k2" } },
+    ]);
+    const h = handlers.get("GET /portal/bundles/:bundleId/objects")!;
+    let status = 0;
+    let body: any = null;
+    await h({ headers: { cookie: "lf_recipient_sess=tok" }, params: { bundleId: "B1" } } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json(p: any) {
+        body = p;
+      },
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(200);
+    expect(body?.items?.length).toBe(2);
+    // Ensure we asked DB with isEnabled filter and sort
+    const args = db.bundleObject.findMany.mock.calls[0]?.[0] ?? {};
+    expect(args?.where?.isEnabled).toBe(true);
+    expect(args?.orderBy?.sortOrder).toBe("asc");
+  });
+
+  it("GET /portal/bundles/:bundleId enforces verification", async () => {
+    const { handlers, storage } = makeServer();
+    const { registerPortalRoutes } = await import("../../src/routes/portal.js");
+    registerPortalRoutes({ get: serverGet } as any, { storage });
+    function serverGet(path: string, h: HttpHandler) {
+      handlers.set(`GET ${path}`, h);
+    }
+    db.recipientSession.findUnique.mockResolvedValue({
+      jti: "tok",
+      recipientId: "R1",
+      expiresAt: futureDate(),
+    });
+    db.recipient.findUnique.mockResolvedValue({ id: "R1", isEnabled: true });
+    db.bundleAssignment.findFirst.mockResolvedValue({
+      id: "A1",
+      bundleId: "B1",
+      recipientId: "R1",
+      isEnabled: true,
+      verificationType: "OTP",
+      verificationMet: false,
+    });
+    const h = handlers.get("GET /portal/bundles/:bundleId")!;
+    let status = 0;
+    let body: any = null;
+    await h({ headers: { cookie: "lf_recipient_sess=tok" }, params: { bundleId: "B1" } } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json(p: any) {
+        body = p;
+      },
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(403);
+    expect(body?.code).toBe("VERIFICATION_REQUIRED");
+  });
+
+  it("GET /portal/bundles/:bundleId streams bundle when allowed", async () => {
+    const { handlers, storage } = makeServer();
+    const { registerPortalRoutes } = await import("../../src/routes/portal.js");
+    registerPortalRoutes({ get: serverGet } as any, { storage });
+    function serverGet(path: string, h: HttpHandler) {
+      handlers.set(`GET ${path}`, h);
+    }
+    db.recipientSession.findUnique.mockResolvedValue({
+      jti: "tok",
+      recipientId: "R1",
+      expiresAt: futureDate(),
+    });
+    db.recipient.findUnique.mockResolvedValue({ id: "R1", isEnabled: true });
+    db.bundleAssignment.findFirst.mockResolvedValue({
+      id: "A1",
+      bundleId: "B1",
+      recipientId: "R1",
+      isEnabled: true,
+      verificationType: null,
+      verificationMet: true,
+      lastDownloadAt: null,
+      cooldownSeconds: null,
+      maxDownloads: null,
+    });
+    db.downloadEvent.count.mockResolvedValue(0);
+    db.bundle.findUnique.mockResolvedValue({
+      id: "B1",
+      storagePath: "objects/sha256/aa/bb/hhh",
+      checksum: "etag",
+    });
+    const h = handlers.get("GET /portal/bundles/:bundleId")!;
+    let sent = false;
+    await h({ headers: { cookie: "lf_recipient_sess=tok" }, params: { bundleId: "B1" } } as any, {
+      status() {
+        return this as any;
+      },
+      json() {},
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {
+        sent = true;
+      },
+      sendBuffer() {},
+    });
+    expect(sent).toBe(true);
+    expect(db.downloadEvent.create).toHaveBeenCalledOnce();
+    expect(db.bundleAssignment.update).toHaveBeenCalledOnce();
+  });
+
+  it("GET /portal/bundles/:bundleId returns 429 during cooldown window", async () => {
+    const { handlers, storage } = makeServer();
+    const { registerPortalRoutes } = await import("../../src/routes/portal.js");
+    registerPortalRoutes({ get: serverGet } as any, { storage });
+    function serverGet(path: string, h: HttpHandler) {
+      handlers.set(`GET ${path}`, h);
+    }
+    db.recipientSession.findUnique.mockResolvedValue({
+      jti: "tok",
+      recipientId: "R1",
+      expiresAt: futureDate(),
+    });
+    db.recipient.findUnique.mockResolvedValue({ id: "R1", isEnabled: true });
+    db.bundleAssignment.findFirst.mockResolvedValue({
+      id: "A1",
+      bundleId: "B1",
+      recipientId: "R1",
+      isEnabled: true,
+      verificationType: null,
+      verificationMet: true,
+      lastDownloadAt: new Date(Date.now() - 2000),
+      cooldownSeconds: 10,
+      maxDownloads: null,
+    });
+    const h = handlers.get("GET /portal/bundles/:bundleId")!;
+    let status = 0;
+    let body: any = null;
+    await h({ headers: { cookie: "lf_recipient_sess=tok" }, params: { bundleId: "B1" } } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json(p: any) {
+        body = p;
+      },
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(429);
+    expect(body?.code).toBe("COOLDOWN_ACTIVE");
+  });
+
+  it("GET /portal/bundles/:bundleId returns 403 when maxDownloads reached", async () => {
+    const { handlers, storage } = makeServer();
+    const { registerPortalRoutes } = await import("../../src/routes/portal.js");
+    registerPortalRoutes({ get: serverGet } as any, { storage });
+    function serverGet(path: string, h: HttpHandler) {
+      handlers.set(`GET ${path}`, h);
+    }
+    db.recipientSession.findUnique.mockResolvedValue({
+      jti: "tok",
+      recipientId: "R1",
+      expiresAt: futureDate(),
+    });
+    db.recipient.findUnique.mockResolvedValue({ id: "R1", isEnabled: true });
+    db.bundleAssignment.findFirst.mockResolvedValue({
+      id: "A1",
+      bundleId: "B1",
+      recipientId: "R1",
+      isEnabled: true,
+      verificationType: null,
+      verificationMet: true,
+      lastDownloadAt: null,
+      cooldownSeconds: null,
+      maxDownloads: 3,
+    });
+    db.downloadEvent.count.mockResolvedValue(3);
+    const h = handlers.get("GET /portal/bundles/:bundleId")!;
+    let status = 0;
+    let body: any = null;
+    await h({ headers: { cookie: "lf_recipient_sess=tok" }, params: { bundleId: "B1" } } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json(p: any) {
+        body = p;
+      },
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(403);
+    expect(body?.code).toBe("MAX_DOWNLOADS_EXCEEDED");
+  });
+
+  it("returns 403 when recipient is disabled", async () => {
+    const { handlers, storage } = makeServer();
+    const { registerPortalRoutes } = await import("../../src/routes/portal.js");
+    registerPortalRoutes({ get: serverGet } as any, { storage });
+    function serverGet(path: string, h: HttpHandler) {
+      handlers.set(`GET ${path}`, h);
+    }
+    db.recipientSession.findUnique.mockResolvedValue({
+      jti: "tok",
+      recipientId: "R1",
+      expiresAt: futureDate(),
+    });
+    db.recipient.findUnique.mockResolvedValue({ id: "R1", isEnabled: false });
+    const h = handlers.get("GET /portal/me")!;
+    let status = 0;
+    await h({ headers: { cookie: "lf_recipient_sess=tok" } } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json() {},
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(403);
+  });
+});

--- a/packages/db/prisma/migrations/20250912203724_add_recip_bundle_enabled/migration.sql
+++ b/packages/db/prisma/migrations/20250912203724_add_recip_bundle_enabled/migration.sql
@@ -1,0 +1,52 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `bundleId` on the `RecipientOtp` table. All the data in the column will be lost.
+  - You are about to drop the column `bundleId` on the `RecipientSession` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[bundleId,recipientId]` on the table `BundleAssignment` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "public"."BundleObject_bundleId_sortOrder_idx";
+
+-- DropIndex
+DROP INDEX "public"."RecipientOtp_recipientId_bundleId_idx";
+
+-- DropIndex
+DROP INDEX "public"."RecipientSession_recipientId_bundleId_idx";
+
+-- AlterTable
+ALTER TABLE "public"."Bundle" ADD COLUMN     "isEnabled" BOOLEAN NOT NULL DEFAULT true;
+
+-- AlterTable
+ALTER TABLE "public"."BundleAssignment" ADD COLUMN     "isEnabled" BOOLEAN NOT NULL DEFAULT true;
+
+-- AlterTable
+ALTER TABLE "public"."BundleObject" ADD COLUMN     "isEnabled" BOOLEAN NOT NULL DEFAULT true;
+
+-- AlterTable
+ALTER TABLE "public"."Recipient" ADD COLUMN     "isEnabled" BOOLEAN NOT NULL DEFAULT true;
+
+-- AlterTable
+ALTER TABLE "public"."RecipientOtp" DROP COLUMN "bundleId";
+
+-- AlterTable
+ALTER TABLE "public"."RecipientSession" DROP COLUMN "bundleId";
+
+-- CreateIndex
+CREATE INDEX "BundleAssignment_bundleId_recipientId_isEnabled_idx" ON "public"."BundleAssignment"("bundleId", "recipientId", "isEnabled");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BundleAssignment_bundleId_recipientId_key" ON "public"."BundleAssignment"("bundleId", "recipientId");
+
+-- CreateIndex
+CREATE INDEX "BundleObject_bundleId_isEnabled_sortOrder_idx" ON "public"."BundleObject"("bundleId", "isEnabled", "sortOrder");
+
+-- CreateIndex
+CREATE INDEX "Recipient_isEnabled_idx" ON "public"."Recipient"("isEnabled");
+
+-- CreateIndex
+CREATE INDEX "RecipientOtp_recipientId_idx" ON "public"."RecipientOtp"("recipientId");
+
+-- CreateIndex
+CREATE INDEX "RecipientSession_recipientId_expiresAt_idx" ON "public"."RecipientSession"("recipientId", "expiresAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -130,6 +130,7 @@ model Recipient {
   id                String             @id @default(uuid())
   email             String             @unique
   name              String?
+  isEnabled         Boolean            @default(true)
   bundleAssignments BundleAssignment[]
   createdAt         DateTime           @default(now())
   updatedAt         DateTime           @updatedAt
@@ -138,6 +139,8 @@ model Recipient {
 
   creator User  @relation("createdRecipients", fields: [createdBy], references: [id])
   updater User? @relation("updatedRecipients", fields: [updatedBy], references: [id])
+
+  @@index([isEnabled])
 }
 
 model File {
@@ -191,6 +194,7 @@ model Bundle {
   storagePath   String
   checksum      String
   description   String?
+  isEnabled     Boolean            @default(true)
   bundleObjects BundleObject[]
   assignments   BundleAssignment[]
   createdAt     DateTime           @default(now())
@@ -210,6 +214,7 @@ model BundleObject {
   sortOrder Int     @default(0)
   required  Boolean @default(false)
   notes     String?
+  isEnabled Boolean @default(true)
 
   addedAt   DateTime @default(now())
   createdBy String
@@ -221,13 +226,14 @@ model BundleObject {
   bundle  Bundle @relation(fields: [bundleId], references: [id], onDelete: Cascade)
 
   @@unique([bundleId, fileId]) // a file appears at most once per bundle (adjust if you want duplicates)
-  @@index([bundleId, sortOrder])
+  @@index([bundleId, isEnabled, sortOrder])
 }
 
 model BundleAssignment {
   id               String            @id @default(uuid())
   bundleId         String
   recipientId      String
+  isEnabled        Boolean           @default(true)
   maxDownloads     Int?
   cooldownSeconds  Int?
   verificationType VerificationType?
@@ -243,6 +249,9 @@ model BundleAssignment {
   updater   User?     @relation("updatedBundleAssignments", fields: [updatedBy], references: [id])
   recipient Recipient @relation(fields: [recipientId], references: [id])
   bundle    Bundle    @relation(fields: [bundleId], references: [id])
+
+  @@unique([bundleId, recipientId])
+  @@index([bundleId, recipientId, isEnabled])
 }
 
 model DownloadEvent {
@@ -549,7 +558,6 @@ model MagicLink {
 model RecipientSession {
   id          String    @id @default(uuid())
   recipientId String
-  bundleId    String
   jti         String    @unique
   createdAt   DateTime  @default(now())
   expiresAt   DateTime
@@ -557,19 +565,18 @@ model RecipientSession {
   ip          String?
   userAgent   String?
 
-  @@index([recipientId, bundleId])
+  @@index([recipientId, expiresAt])
 }
 
 model RecipientOtp {
   id          String   @id @default(uuid())
   recipientId String
-  bundleId    String
   codeHash    String
   createdAt   DateTime @default(now())
   expiresAt   DateTime
   attempts    Int      @default(0)
 
-  @@index([recipientId, bundleId])
+  @@index([recipientId])
 }
 
 ///////////////////////////

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       '@types/node':
         specifier: ^20.11.0
         version: 20.19.9
+      '@types/nodemailer':
+        specifier: ^6.4.15
+        version: 6.4.19
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.6.0
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
@@ -245,40 +248,80 @@ packages:
     resolution: {integrity: sha512-+l/p5G/bbobzcils5wKSV1vQEITvJIXDkLfkMWLpF6CC3YfdSDlVn1VOD+NcfuOuVGv4UkwcJzWuC6eaX6t8jg==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/client-ses@3.888.0':
+    resolution: {integrity: sha512-d+mxbE8HxTF5TWAfpSL8yNpR62PfBCO5cXEAvxJq2ftvMlNPwRdyRqRddl2+86nQAnm5y6RChBkFIxr0np/F2g==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/client-sso@3.883.0':
     resolution: {integrity: sha512-Ybjw76yPceEBO7+VLjy5+/Gr0A1UNymSDHda5w8tfsS2iHZt/vuD6wrYpHdLoUx4H5la8ZhwcSfK/+kmE+QLPw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/client-sso@3.888.0':
+    resolution: {integrity: sha512-8CLy/ehGKUmekjH+VtZJ4w40PqDg3u0K7uPziq/4P8Q7LLgsy8YQoHNbuY4am7JU3HWrqLXJI9aaz1+vPGPoWA==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/core@3.883.0':
     resolution: {integrity: sha512-FmkqnqBLkXi4YsBPbF6vzPa0m4XKUuvgKDbamfw4DZX2CzfBZH6UU4IwmjNV3ZM38m0xraHarK8KIbGSadN3wg==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/core@3.888.0':
+    resolution: {integrity: sha512-L3S2FZywACo4lmWv37Y4TbefuPJ1fXWyWwIJ3J4wkPYFJ47mmtUPqThlVrSbdTHkEjnZgJe5cRfxk0qCLsFh1w==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/credential-provider-env@3.883.0':
     resolution: {integrity: sha512-Z6tPBXPCodfhIF1rvQKoeRGMkwL6TK0xdl1UoMIA1x4AfBpPICAF77JkFBExk/pdiFYq1d04Qzddd/IiujSlLg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.888.0':
+    resolution: {integrity: sha512-shPi4AhUKbIk7LugJWvNpeZA8va7e5bOHAEKo89S0Ac8WDZt2OaNzbh/b9l0iSL2eEyte8UgIsYGcFxOwIF1VA==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/credential-provider-http@3.883.0':
     resolution: {integrity: sha512-P589ug1lMOOEYLTaQJjSP+Gee34za8Kk2LfteNQfO9SpByHFgGj++Sg8VyIe30eZL8Q+i4qTt24WDCz1c+dgYg==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.888.0':
+    resolution: {integrity: sha512-Jvuk6nul0lE7o5qlQutcqlySBHLXOyoPtiwE6zyKbGc7RVl0//h39Lab7zMeY2drMn8xAnIopL4606Fd8JI/Hw==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.883.0':
     resolution: {integrity: sha512-n6z9HTzuDEdugXvPiE/95VJXbF4/gBffdV/SRHDJKtDHaRuvp/gggbfmfVSTFouGVnlKPb2pQWQsW3Nr/Y3Lrw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.888.0':
+    resolution: {integrity: sha512-M82ItvS5yq+tO6ZOV1ruaVs2xOne+v8HW85GFCXnz8pecrzYdgxh6IsVqEbbWruryG/mUGkWMbkBZoEsy4MgyA==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/credential-provider-node@3.883.0':
     resolution: {integrity: sha512-QIUhsatsrwfB9ZsKpmi0EySSfexVP61wgN7hr493DOileh2QsKW4XATEfsWNmx0dj9323Vg1Mix7bXtRfl9cGg==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.888.0':
+    resolution: {integrity: sha512-KCrQh1dCDC8Y+Ap3SZa6S81kHk+p+yAaOQ5jC3dak4zhHW3RCrsGR/jYdemTOgbEGcA6ye51UbhWfrrlMmeJSA==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/credential-provider-process@3.883.0':
     resolution: {integrity: sha512-m1shbHY/Vppy4EdddG9r8x64TO/9FsCjokp5HbKcZvVoTOTgUJrdT8q2TAQJ89+zYIJDqsKbqfrmfwJ1zOdnGQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.888.0':
+    resolution: {integrity: sha512-+aX6piSukPQ8DUS4JAH344GePg8/+Q1t0+kvSHAZHhYvtQ/1Zek3ySOJWH2TuzTPCafY4nmWLcQcqvU1w9+4Lw==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.883.0':
     resolution: {integrity: sha512-37ve9Tult08HLXrJFHJM/sGB/vO7wzI6v1RUUfeTiShqx8ZQ5fTzCTNY/duO96jCtCexmFNSycpQzh7lDIf0aA==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.888.0':
+    resolution: {integrity: sha512-b1ZJji7LJ6E/j1PhFTyvp51in2iCOQ3VP6mj5H6f5OUnqn7efm41iNMoinKr87n0IKZw7qput5ggXVxEdPhouA==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.883.0':
     resolution: {integrity: sha512-SL82K9Jb0vpuTadqTO4Fpdu7SKtebZ3Yo4LZvk/U0UauVMlJj5ZTos0mFx1QSMB9/4TpqifYrSZcdnxgYg8Eqw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.888.0':
+    resolution: {integrity: sha512-7P0QNtsDzMZdmBAaY/vY1BsZHwTGvEz3bsn2bm5VSKFAeMmZqsHK1QeYdNsFjLtegnVh+wodxMq50jqLv3LFlA==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/middleware-bucket-endpoint@3.873.0':
@@ -297,6 +340,10 @@ packages:
     resolution: {integrity: sha512-KZ/W1uruWtMOs7D5j3KquOxzCnV79KQW9MjJFZM/M0l6KI8J6V3718MXxFHsTjUE4fpdV6SeCNLV1lwGygsjJA==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/middleware-host-header@3.887.0':
+    resolution: {integrity: sha512-ulzqXv6NNqdu/kr0sgBYupWmahISHY+azpJidtK6ZwQIC+vBUk9NdZeqQpy7KVhIk2xd4+5Oq9rxapPwPI21CA==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/middleware-location-constraint@3.873.0':
     resolution: {integrity: sha512-r+hIaORsW/8rq6wieDordXnA/eAu7xAPLue2InhoEX6ML7irP52BgiibHLpt9R0psiCzIHhju8qqKa4pJOrmiw==}
     engines: {node: '>=18.0.0'}
@@ -305,8 +352,16 @@ packages:
     resolution: {integrity: sha512-cpWJhOuMSyz9oV25Z/CMHCBTgafDCbv7fHR80nlRrPdPZ8ETNsahwRgltXP1QJJ8r3X/c1kwpOR7tc+RabVzNA==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/middleware-logger@3.887.0':
+    resolution: {integrity: sha512-YbbgLI6jKp2qSoAcHnXrQ5jcuc5EYAmGLVFgMVdk8dfCfJLfGGSaOLxF4CXC7QYhO50s+mPPkhBYejCik02Kug==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/middleware-recursion-detection@3.873.0':
     resolution: {integrity: sha512-OtgY8EXOzRdEWR//WfPkA/fXl0+WwE8hq0y9iw2caNyKPtca85dzrrZWnPqyBK/cpImosrpR1iKMYr41XshsCg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.887.0':
+    resolution: {integrity: sha512-tjrUXFtQnFLo+qwMveq5faxP5MQakoLArXtqieHphSqZTXm21wDJM73hgT4/PQQGTwgYjDKqnqsE1hvk0hcfDw==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/middleware-sdk-s3@3.883.0':
@@ -321,12 +376,24 @@ packages:
     resolution: {integrity: sha512-q58uLYnGLg7hsnWpdj7Cd1Ulsq1/PUJOHvAfgcBuiDE/+Fwh0DZxZZyjrU+Cr+dbeowIdUaOO8BEDDJ0CUenJw==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/middleware-user-agent@3.888.0':
+    resolution: {integrity: sha512-ZkcUkoys8AdrNNG7ATjqw2WiXqrhTvT+r4CIK3KhOqIGPHX0p0DQWzqjaIl7ZhSUToKoZ4Ud7MjF795yUr73oA==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/nested-clients@3.883.0':
     resolution: {integrity: sha512-IhzDM+v0ga53GOOrZ9jmGNr7JU5OR6h6ZK9NgB7GXaa+gsDbqfUuXRwyKDYXldrTXf1sUR3vy1okWDXA7S2ejQ==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/nested-clients@3.888.0':
+    resolution: {integrity: sha512-py4o4RPSGt+uwGvSBzR6S6cCBjS4oTX5F8hrHFHfPCdIOMVjyOBejn820jXkCrcdpSj3Qg1yUZXxsByvxc9Lyg==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/region-config-resolver@3.873.0':
     resolution: {integrity: sha512-q9sPoef+BBG6PJnc4x60vK/bfVwvRWsPgcoQyIra057S/QGjq5VkjvNk6H8xedf6vnKlXNBwq9BaANBXnldUJg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.887.0':
+    resolution: {integrity: sha512-VdSMrIqJ3yjJb/fY+YAxrH/lCVv0iL8uA+lbMNfQGtO5tB3Zx6SU9LEpUwBNX8fPK1tUpI65CNE4w42+MY/7Mg==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/s3-request-presigner@3.883.0':
@@ -341,8 +408,16 @@ packages:
     resolution: {integrity: sha512-tcj/Z5paGn9esxhmmkEW7gt39uNoIRbXG1UwJrfKu4zcTr89h86PDiIE2nxUO3CMQf1KgncPpr5WouPGzkh/QQ==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/token-providers@3.888.0':
+    resolution: {integrity: sha512-WA3NF+3W8GEuCMG1WvkDYbB4z10G3O8xuhT7QSjhvLYWQ9CPt3w4VpVIfdqmUn131TCIbhCzD0KN/1VJTjAjyw==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/types@3.862.0':
     resolution: {integrity: sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/types@3.887.0':
+    resolution: {integrity: sha512-fmTEJpUhsPsovQ12vZSpVTEP/IaRoJAMBGQXlQNjtCpkBp6Iq3KQDa/HDaPINE+3xxo6XvTdtibsNOd5zJLV9A==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/util-arn-parser@3.873.0':
@@ -351,6 +426,10 @@ packages:
 
   '@aws-sdk/util-endpoints@3.879.0':
     resolution: {integrity: sha512-aVAJwGecYoEmbEFju3127TyJDF9qJsKDUUTRMDuS8tGn+QiWQFnfInmbt+el9GU1gEJupNTXV+E3e74y51fb7A==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/util-endpoints@3.887.0':
+    resolution: {integrity: sha512-kpegvT53KT33BMeIcGLPA65CQVxLUL/C3gTz9AzlU/SDmeusBHX4nRApAicNzI/ltQ5lxZXbQn18UczzBuwF1w==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/util-format-url@3.873.0':
@@ -364,6 +443,9 @@ packages:
   '@aws-sdk/util-user-agent-browser@3.873.0':
     resolution: {integrity: sha512-AcRdbK6o19yehEcywI43blIBhOCSo6UgyWcuOJX5CFF8k39xm1ILCjQlRRjchLAxWrm0lU0Q7XV90RiMMFMZtA==}
 
+  '@aws-sdk/util-user-agent-browser@3.887.0':
+    resolution: {integrity: sha512-X71UmVsYc6ZTH4KU6hA5urOzYowSXc3qvroagJNLJYU1ilgZ529lP4J9XOYfEvTXkLR1hPFSRxa43SrwgelMjA==}
+
   '@aws-sdk/util-user-agent-node@3.883.0':
     resolution: {integrity: sha512-28cQZqC+wsKUHGpTBr+afoIdjS6IoEJkMqcZsmo2Ag8LzmTa6BUWQenFYB0/9BmDy4PZFPUn+uX+rJgWKB+jzA==}
     engines: {node: '>=18.0.0'}
@@ -373,8 +455,25 @@ packages:
       aws-crt:
         optional: true
 
+  '@aws-sdk/util-user-agent-node@3.888.0':
+    resolution: {integrity: sha512-rSB3OHyuKXotIGfYEo//9sU0lXAUrTY28SUUnxzOGYuQsAt0XR5iYwBAp+RjV6x8f+Hmtbg0PdCsy1iNAXa0UQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
   '@aws-sdk/xml-builder@3.873.0':
     resolution: {integrity: sha512-kLO7k7cGJ6KaHiExSJWojZurF7SnGMDHXRuQunFnEoD0n1yB6Lqy/S/zHiQ7oJnBhPr9q0TW9qFkrsZb1Uc54w==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/xml-builder@3.887.0':
+    resolution: {integrity: sha512-lMwgWK1kNgUhHGfBvO/5uLe7TKhycwOn3eRCqsKPT9aPCx/HWuTlpcQp8oW2pCRGLS7qzcxqpQulcD+bbUL7XQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws/lambda-invoke-store@0.0.1':
+    resolution: {integrity: sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==}
     engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
@@ -1242,6 +1341,10 @@ packages:
     resolution: {integrity: sha512-wEhSYznxOmx7EdwK1tYEWJF5+/wmSFsff9BfTOn8oO/+KPl3gsmThrb6MJlWbOC391+Ya31s5JuHiC2RlT80Zg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/abort-controller@4.1.1':
+    resolution: {integrity: sha512-vkzula+IwRvPR6oKQhMYioM3A/oX/lFCZiwuxkQbRhqJS2S4YRY2k7k/SyR2jMf3607HLtbEwlRxi0ndXHMjRg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/chunked-blob-reader-native@4.1.0':
     resolution: {integrity: sha512-Bnv0B3nSlfB2mPO0WgM49I/prl7+kamF042rrf3ezJ3Z4C7csPYvyYgZfXTGXwXfj1mAwDWjE/ybIf49PzFzvA==}
     engines: {node: '>=18.0.0'}
@@ -1254,12 +1357,24 @@ packages:
     resolution: {integrity: sha512-FA10YhPFLy23uxeWu7pOM2ctlw+gzbPMTZQwrZ8FRIfyJ/p8YIVz7AVTB5jjLD+QIerydyKcVMZur8qzzDILAQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/config-resolver@4.2.1':
+    resolution: {integrity: sha512-FXil8q4QN7mgKwU2hCLm0ltab8NyY/1RiqEf25Jnf6WLS3wmb11zGAoLETqg1nur2Aoibun4w4MjeN9CMJ4G6A==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/core@3.10.0':
     resolution: {integrity: sha512-bXyD3Ij6b1qDymEYlEcF+QIjwb9gObwZNaRjETJsUEvSIzxFdynSQ3E4ysY7lUFSBzeWBNaFvX+5A0smbC2q6A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.11.0':
+    resolution: {integrity: sha512-Abs5rdP1o8/OINtE49wwNeWuynCu0kme1r4RI3VXVrHr4odVDG7h7mTnw1WXXfN5Il+c25QOnrdL2y56USfxkA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.1.0':
     resolution: {integrity: sha512-iVwNhxTsCQTPdp++4C/d9xvaDmuEWhXi55qJobMp9QMaEHRGH3kErU4F8gohtdsawRqnUy/ANylCjKuhcR2mPw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.1.1':
+    resolution: {integrity: sha512-1WdBfM9DwA59pnpIizxnUvBf/de18p4GP+6zP2AqrlFzoW3ERpZaT4QueBR0nS9deDMaQRkBlngpVlnkuuTisQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.1.0':
@@ -1286,6 +1401,10 @@ packages:
     resolution: {integrity: sha512-VZenjDdVaUGiy3hwQtxm75nhXZrhFG+3xyL93qCQAlYDyhT/jeDWM8/3r5uCFMlTmmyrIjiDyiOynVFchb0BSg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/fetch-http-handler@5.2.1':
+    resolution: {integrity: sha512-5/3wxKNtV3wO/hk1is+CZUhL8a1yy/U+9u9LKQ9kZTkMsHaQjJhc3stFfiujtMnkITjzWfndGA2f7g9Uh9vKng==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/hash-blob-browser@4.1.0':
     resolution: {integrity: sha512-brRgh2qEYPHYImfqoQB/xfcT/CjSz9Z/dH2vURSS0lIw3bImFK5t15l4iypwRw4GtZlZTK/VsLqsR54OJWRerg==}
     engines: {node: '>=18.0.0'}
@@ -1294,12 +1413,20 @@ packages:
     resolution: {integrity: sha512-mXkJQ/6lAXTuoSsEH+d/fHa4ms4qV5LqYoPLYhmhCRTNcMMdg+4Ya8cMgU1W8+OR40eX0kzsExT7fAILqtTl2w==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/hash-node@4.1.1':
+    resolution: {integrity: sha512-H9DIU9WBLhYrvPs9v4sYvnZ1PiAI0oc8CgNQUJ1rpN3pP7QADbTOUjchI2FB764Ub0DstH5xbTqcMJu1pnVqxA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/hash-stream-node@4.1.0':
     resolution: {integrity: sha512-9TToqq62msanK/L6pV1ZAOm2+1VgCz9gE6/TVJhZXV352DnAItaO9jx6FFGujUDXrRJV0lpwe4c0vymz/vXMUQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/invalid-dependency@4.1.0':
     resolution: {integrity: sha512-4/FcV6aCMzgpM4YyA/GRzTtG28G0RQJcWK722MmpIgzOyfSceWcI9T9c8matpHU9qYYLaWtk8pSGNCLn5kzDRw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.1.1':
+    resolution: {integrity: sha512-1AqLyFlfrrDkyES8uhINRlJXmHA2FkG+3DY8X+rmLSqmFwk3DJnvhyGzyByPyewh2jbmV+TYQBEfngQax8IFGg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -1318,52 +1445,104 @@ packages:
     resolution: {integrity: sha512-x3dgLFubk/ClKVniJu+ELeZGk4mq7Iv0HgCRUlxNUIcerHTLVmq7Q5eGJL0tOnUltY6KFw5YOKaYxwdcMwox/w==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-content-length@4.1.1':
+    resolution: {integrity: sha512-9wlfBBgTsRvC2JxLJxv4xDGNBrZuio3AgSl0lSFX7fneW2cGskXTYpFxCdRYD2+5yzmsiTuaAJD1Wp7gWt9y9w==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/middleware-endpoint@4.2.0':
     resolution: {integrity: sha512-J1eCF7pPDwgv7fGwRd2+Y+H9hlIolF3OZ2PjptonzzyOXXGh/1KGJAHpEcY1EX+WLlclKu2yC5k+9jWXdUG4YQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.2.1':
+    resolution: {integrity: sha512-fUTMmQvQQZakXOuKizfu7fBLDpwvWZjfH6zUK2OLsoNZRZGbNUdNSdLJHpwk1vS208jtDjpUIskh+JoA8zMzZg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-retry@4.2.0':
     resolution: {integrity: sha512-raL5oWYf5ALl3jCJrajE8enKJEnV/2wZkKS6mb3ZRY2tg3nj66ssdWy5Ps8E6Yu8Wqh3Tt+Sb9LozjvwZupq+A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-retry@4.2.1':
+    resolution: {integrity: sha512-JzfvjwSJXWRl7LkLgIRTUTd2Wj639yr3sQGpViGNEOjtb0AkAuYqRAHs+jSOI/LPC0ZTjmFVVtfrCICMuebexw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/middleware-serde@4.1.0':
     resolution: {integrity: sha512-CtLFYlHt7c2VcztyVRc+25JLV4aGpmaSv9F1sPB0AGFL6S+RPythkqpGDa2XBQLJQooKkjLA1g7Xe4450knShg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.1.1':
+    resolution: {integrity: sha512-lh48uQdbCoj619kRouev5XbWhCwRKLmphAif16c4J6JgJ4uXjub1PI6RL38d3BLliUvSso6klyB/LTNpWSNIyg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-stack@4.1.0':
     resolution: {integrity: sha512-91Fuw4IKp0eK8PNhMXrHRcYA1jvbZ9BJGT91wwPy3bTQT8mHTcQNius/EhSQTlT9QUI3Ki1wjHeNXbWK0tO8YQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-stack@4.1.1':
+    resolution: {integrity: sha512-ygRnniqNcDhHzs6QAPIdia26M7e7z9gpkIMUe/pK0RsrQ7i5MblwxY8078/QCnGq6AmlUUWgljK2HlelsKIb/A==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-config-provider@4.2.0':
     resolution: {integrity: sha512-8/fpilqKurQ+f8nFvoFkJ0lrymoMJ+5/CQV5IcTv/MyKhk2Q/EFYCAgTSWHD4nMi9ux9NyBBynkyE9SLg2uSLA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.2.1':
+    resolution: {integrity: sha512-AIA0BJZq2h295J5NeCTKhg1WwtdTA/GqBCaVjk30bDgMHwniUETyh5cP9IiE9VrId7Kt8hS7zvREVMTv1VfA6g==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.2.0':
     resolution: {integrity: sha512-G4NV70B4hF9vBrUkkvNfWO6+QR4jYjeO4tc+4XrKCb4nPYj49V9Hu8Ftio7Mb0/0IlFyEOORudHrm+isY29nCA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.2.1':
+    resolution: {integrity: sha512-REyybygHlxo3TJICPF89N2pMQSf+p+tBJqpVe1+77Cfi9HBPReNjTgtZ1Vg73exq24vkqJskKDpfF74reXjxfw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.1.0':
     resolution: {integrity: sha512-eksMjMHUlG5PwOUWO3k+rfLNOPVPJ70mUzyYNKb5lvyIuAwS4zpWGsxGiuT74DFWonW0xRNy+jgzGauUzX7SyA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.1.1':
+    resolution: {integrity: sha512-gm3ZS7DHxUbzC2wr8MUCsAabyiXY0gaj3ROWnhSx/9sPMc6eYLMM4rX81w1zsMaObj2Lq3PZtNCC1J6lpEY7zg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/protocol-http@5.2.0':
     resolution: {integrity: sha512-bwjlh5JwdOQnA01be+5UvHK4HQz4iaRKlVG46hHSJuqi0Ribt3K06Z1oQ29i35Np4G9MCDgkOGcHVyLMreMcbg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/protocol-http@5.2.1':
+    resolution: {integrity: sha512-T8SlkLYCwfT/6m33SIU/JOVGNwoelkrvGjFKDSDtVvAXj/9gOT78JVJEas5a+ETjOu4SVvpCstKgd0PxSu/aHw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/querystring-builder@4.1.0':
     resolution: {integrity: sha512-JqTWmVIq4AF8R8OK/2cCCiQo5ZJ0SRPsDkDgLO5/3z8xxuUp1oMIBBjfuueEe+11hGTZ6rRebzYikpKc6yQV9Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.1.1':
+    resolution: {integrity: sha512-J9b55bfimP4z/Jg1gNo+AT84hr90p716/nvxDkPGCD4W70MPms0h8KF50RDRgBGZeL83/u59DWNqJv6tEP/DHA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/querystring-parser@4.1.0':
     resolution: {integrity: sha512-VgdHhr8YTRsjOl4hnKFm7xEMOCRTnKw3FJ1nU+dlWNhdt/7eEtxtkdrJdx7PlRTabdANTmvyjE4umUl9cK4awg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/querystring-parser@4.1.1':
+    resolution: {integrity: sha512-63TEp92YFz0oQ7Pj9IuI3IgnprP92LrZtRAkE3c6wLWJxfy/yOPRt39IOKerVr0JS770olzl0kGafXlAXZ1vng==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/service-error-classification@4.1.0':
     resolution: {integrity: sha512-UBpNFzBNmS20jJomuYn++Y+soF8rOK9AvIGjS9yGP6uRXF5rP18h4FDUsoNpWTlSsmiJ87e2DpZo9ywzSMH7PQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/service-error-classification@4.1.1':
+    resolution: {integrity: sha512-Iam75b/JNXyDE41UvrlM6n8DNOa/r1ylFyvgruTUx7h2Uk7vDNV9AAwP1vfL1fOL8ls0xArwEGVcGZVd7IO/Cw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/shared-ini-file-loader@4.1.0':
     resolution: {integrity: sha512-W0VMlz9yGdQ/0ZAgWICFjFHTVU0YSfGoCVpKaExRM/FDkTeP/yz8OKvjtGjs6oFokCRm0srgj/g4Cg0xuHu8Rw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.1.1':
+    resolution: {integrity: sha512-YkpikhIqGc4sfXeIbzSj10t2bJI/sSoP5qxLue6zG+tEE3ngOBSm8sO3+djacYvS/R5DfpxN/L9CyZsvwjWOAQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.2.0':
@@ -1374,12 +1553,24 @@ packages:
     resolution: {integrity: sha512-TvlIshqx5PIi0I0AiR+PluCpJ8olVG++xbYkAIGCUkByaMUlfOXLgjQTmYbr46k4wuDe8eHiTIlUflnjK2drPQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/smithy-client@4.6.1':
+    resolution: {integrity: sha512-WolVLDb9UTPMEPPOncrCt6JmAMCSC/V2y5gst2STWJ5r7+8iNac+EFYQnmvDCYMfOLcilOSEpm5yXZXwbLak1Q==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/types@4.4.0':
     resolution: {integrity: sha512-4jY91NgZz+ZnSFcVzWwngOW6VuK3gR/ihTwSU1R/0NENe9Jd8SfWgbhDCAGUWL3bI7DiDSW7XF6Ui6bBBjrqXw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/types@4.5.0':
+    resolution: {integrity: sha512-RkUpIOsVlAwUIZXO1dsz8Zm+N72LClFfsNqf173catVlvRZiwPy0x2u0JLEA4byreOPKDZPGjmPDylMoP8ZJRg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/url-parser@4.1.0':
     resolution: {integrity: sha512-/LYEIOuO5B2u++tKr1NxNxhZTrr3A63jW8N73YTwVeUyAlbB/YM+hkftsvtKAcMt3ADYo0FsF1GY3anehffSVQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.1.1':
+    resolution: {integrity: sha512-bx32FUpkhcaKlEoOMbScvc93isaSiRM75pQ5IgIBaMkT7qMlIibpPRONyx/0CvrXHzJLpOn/u6YiDX2hcvs7Dg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-base64@4.1.0':
@@ -1410,12 +1601,24 @@ packages:
     resolution: {integrity: sha512-D27cLtJtC4EEeERJXS+JPoogz2tE5zeE3zhWSSu6ER5/wJ5gihUxIzoarDX6K1U27IFTHit5YfHqU4Y9RSGE0w==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-defaults-mode-browser@4.1.1':
+    resolution: {integrity: sha512-hA1AKIHFUMa9Tl6q6y8p0pJ9aWHCCG8s57flmIyLE0W7HcJeYrYtnqXDcGnftvXEhdQnSexyegXnzzTGk8bKLA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-defaults-mode-node@4.1.0':
     resolution: {integrity: sha512-gnZo3u5dP1o87plKupg39alsbeIY1oFFnCyV2nI/++pL19vTtBLgOyftLEjPjuXmoKn2B2rskX8b7wtC/+3Okg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-defaults-mode-node@4.1.1':
+    resolution: {integrity: sha512-RGSpmoBrA+5D2WjwtK7tto6Pc2wO9KSXKLpLONhFZ8VyuCbqlLdiDAfuDTNY9AJe4JoE+Cx806cpTQQoQ71zPQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-endpoints@3.1.0':
     resolution: {integrity: sha512-5LFg48KkunBVGrNs3dnQgLlMXJLVo7k9sdZV5su3rjO3c3DmQ2LwUZI0Zr49p89JWK6sB7KmzyI2fVcDsZkwuw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.1.1':
+    resolution: {integrity: sha512-qB4R9kO0SetA11Rzu6MVGFIaGYX3p6SGGGfWwsKnC6nXIf0n/0AKVwRTsYsz9ToN8CeNNtNgQRwKFBndGJZdyw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-hex-encoding@4.1.0':
@@ -1426,12 +1629,24 @@ packages:
     resolution: {integrity: sha512-612onNcKyxhP7/YOTKFTb2F6sPYtMRddlT5mZvYf1zduzaGzkYhpYIPxIeeEwBZFjnvEqe53Ijl2cYEfJ9d6/Q==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-middleware@4.1.1':
+    resolution: {integrity: sha512-CGmZ72mL29VMfESz7S6dekqzCh8ZISj3B+w0g1hZFXaOjGTVaSqfAEFAq8EGp8fUL+Q2l8aqNmt8U1tglTikeg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-retry@4.1.0':
     resolution: {integrity: sha512-5AGoBHb207xAKSVwaUnaER+L55WFY8o2RhlafELZR3mB0J91fpL+Qn+zgRkPzns3kccGaF2vy0HmNVBMWmN6dA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-retry@4.1.1':
+    resolution: {integrity: sha512-jGeybqEZ/LIordPLMh5bnmnoIgsqnp4IEimmUp5c5voZ8yx+5kAlN5+juyr7p+f7AtZTgvhmInQk4Q0UVbrZ0Q==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-stream@4.3.0':
     resolution: {integrity: sha512-ZOYS94jksDwvsCJtppHprUhsIscRnCKGr6FXCo3SxgQ31ECbza3wqDBqSy6IsAak+h/oAXb1+UYEBmDdseAjUQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.3.1':
+    resolution: {integrity: sha512-khKkW/Jqkgh6caxMWbMuox9+YfGlsk9OnHOYCGVEdYQb/XVzcORXHLYUubHmmda0pubEDncofUrPNniS9d+uAA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-uri-escape@4.1.0':
@@ -1448,6 +1663,10 @@ packages:
 
   '@smithy/util-waiter@4.1.0':
     resolution: {integrity: sha512-IUuj2zpGdeKaY5OdGnU83BUJsv7OA9uw3rNVSOuvzLMXMpBTU+W6V0SsQh6iI32lKUJArlnEU4BIzp83hghR/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.1.1':
+    resolution: {integrity: sha512-PJBmyayrlfxM7nbqjomF4YcT1sApQwZio0NHSsT0EzhJqljRmvhzqZua43TyEs80nJk2Cn2FGPg/N8phH6KeCQ==}
     engines: {node: '>=18.0.0'}
 
   '@standard-schema/spec@1.0.0':
@@ -1578,6 +1797,9 @@ packages:
 
   '@types/node@24.2.0':
     resolution: {integrity: sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==}
+
+  '@types/nodemailer@6.4.19':
+    resolution: {integrity: sha512-Fi8DwmuAduTk1/1MpkR9EwS0SsDvYXx5RxivAVII1InDCIxmhj/iQm3W8S3EVb/0arnblr6PK0FK4wYa7bwdLg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -4724,6 +4946,51 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-ses@3.888.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.888.0
+      '@aws-sdk/credential-provider-node': 3.888.0
+      '@aws-sdk/middleware-host-header': 3.887.0
+      '@aws-sdk/middleware-logger': 3.887.0
+      '@aws-sdk/middleware-recursion-detection': 3.887.0
+      '@aws-sdk/middleware-user-agent': 3.888.0
+      '@aws-sdk/region-config-resolver': 3.887.0
+      '@aws-sdk/types': 3.887.0
+      '@aws-sdk/util-endpoints': 3.887.0
+      '@aws-sdk/util-user-agent-browser': 3.887.0
+      '@aws-sdk/util-user-agent-node': 3.888.0
+      '@smithy/config-resolver': 4.2.1
+      '@smithy/core': 3.11.0
+      '@smithy/fetch-http-handler': 5.2.1
+      '@smithy/hash-node': 4.1.1
+      '@smithy/invalid-dependency': 4.1.1
+      '@smithy/middleware-content-length': 4.1.1
+      '@smithy/middleware-endpoint': 4.2.1
+      '@smithy/middleware-retry': 4.2.1
+      '@smithy/middleware-serde': 4.1.1
+      '@smithy/middleware-stack': 4.1.1
+      '@smithy/node-config-provider': 4.2.1
+      '@smithy/node-http-handler': 4.2.1
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/smithy-client': 4.6.1
+      '@smithy/types': 4.5.0
+      '@smithy/url-parser': 4.1.1
+      '@smithy/util-base64': 4.1.0
+      '@smithy/util-body-length-browser': 4.1.0
+      '@smithy/util-body-length-node': 4.1.0
+      '@smithy/util-defaults-mode-browser': 4.1.1
+      '@smithy/util-defaults-mode-node': 4.1.1
+      '@smithy/util-endpoints': 3.1.1
+      '@smithy/util-middleware': 4.1.1
+      '@smithy/util-retry': 4.1.1
+      '@smithy/util-utf8': 4.1.0
+      '@smithy/util-waiter': 4.1.1
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/client-sso@3.883.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -4767,6 +5034,49 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-sso@3.888.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.888.0
+      '@aws-sdk/middleware-host-header': 3.887.0
+      '@aws-sdk/middleware-logger': 3.887.0
+      '@aws-sdk/middleware-recursion-detection': 3.887.0
+      '@aws-sdk/middleware-user-agent': 3.888.0
+      '@aws-sdk/region-config-resolver': 3.887.0
+      '@aws-sdk/types': 3.887.0
+      '@aws-sdk/util-endpoints': 3.887.0
+      '@aws-sdk/util-user-agent-browser': 3.887.0
+      '@aws-sdk/util-user-agent-node': 3.888.0
+      '@smithy/config-resolver': 4.2.1
+      '@smithy/core': 3.11.0
+      '@smithy/fetch-http-handler': 5.2.1
+      '@smithy/hash-node': 4.1.1
+      '@smithy/invalid-dependency': 4.1.1
+      '@smithy/middleware-content-length': 4.1.1
+      '@smithy/middleware-endpoint': 4.2.1
+      '@smithy/middleware-retry': 4.2.1
+      '@smithy/middleware-serde': 4.1.1
+      '@smithy/middleware-stack': 4.1.1
+      '@smithy/node-config-provider': 4.2.1
+      '@smithy/node-http-handler': 4.2.1
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/smithy-client': 4.6.1
+      '@smithy/types': 4.5.0
+      '@smithy/url-parser': 4.1.1
+      '@smithy/util-base64': 4.1.0
+      '@smithy/util-body-length-browser': 4.1.0
+      '@smithy/util-body-length-node': 4.1.0
+      '@smithy/util-defaults-mode-browser': 4.1.1
+      '@smithy/util-defaults-mode-node': 4.1.1
+      '@smithy/util-endpoints': 3.1.1
+      '@smithy/util-middleware': 4.1.1
+      '@smithy/util-retry': 4.1.1
+      '@smithy/util-utf8': 4.1.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/core@3.883.0':
     dependencies:
       '@aws-sdk/types': 3.862.0
@@ -4785,12 +5095,38 @@ snapshots:
       fast-xml-parser: 5.2.5
       tslib: 2.6.2
 
+  '@aws-sdk/core@3.888.0':
+    dependencies:
+      '@aws-sdk/types': 3.887.0
+      '@aws-sdk/xml-builder': 3.887.0
+      '@smithy/core': 3.11.0
+      '@smithy/node-config-provider': 4.2.1
+      '@smithy/property-provider': 4.1.0
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/signature-v4': 5.2.0
+      '@smithy/smithy-client': 4.6.1
+      '@smithy/types': 4.5.0
+      '@smithy/util-base64': 4.1.0
+      '@smithy/util-body-length-browser': 4.1.0
+      '@smithy/util-middleware': 4.1.1
+      '@smithy/util-utf8': 4.1.0
+      fast-xml-parser: 5.2.5
+      tslib: 2.6.2
+
   '@aws-sdk/credential-provider-env@3.883.0':
     dependencies:
       '@aws-sdk/core': 3.883.0
       '@aws-sdk/types': 3.862.0
       '@smithy/property-provider': 4.1.0
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@aws-sdk/credential-provider-env@3.888.0':
+    dependencies:
+      '@aws-sdk/core': 3.888.0
+      '@aws-sdk/types': 3.887.0
+      '@smithy/property-provider': 4.1.0
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@aws-sdk/credential-provider-http@3.883.0':
@@ -4804,6 +5140,19 @@ snapshots:
       '@smithy/smithy-client': 4.6.0
       '@smithy/types': 4.4.0
       '@smithy/util-stream': 4.3.0
+      tslib: 2.6.2
+
+  '@aws-sdk/credential-provider-http@3.888.0':
+    dependencies:
+      '@aws-sdk/core': 3.888.0
+      '@aws-sdk/types': 3.887.0
+      '@smithy/fetch-http-handler': 5.2.1
+      '@smithy/node-http-handler': 4.2.1
+      '@smithy/property-provider': 4.1.0
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/smithy-client': 4.6.1
+      '@smithy/types': 4.5.0
+      '@smithy/util-stream': 4.3.1
       tslib: 2.6.2
 
   '@aws-sdk/credential-provider-ini@3.883.0':
@@ -4820,6 +5169,24 @@ snapshots:
       '@smithy/property-provider': 4.1.0
       '@smithy/shared-ini-file-loader': 4.1.0
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-ini@3.888.0':
+    dependencies:
+      '@aws-sdk/core': 3.888.0
+      '@aws-sdk/credential-provider-env': 3.888.0
+      '@aws-sdk/credential-provider-http': 3.888.0
+      '@aws-sdk/credential-provider-process': 3.888.0
+      '@aws-sdk/credential-provider-sso': 3.888.0
+      '@aws-sdk/credential-provider-web-identity': 3.888.0
+      '@aws-sdk/nested-clients': 3.888.0
+      '@aws-sdk/types': 3.887.0
+      '@smithy/credential-provider-imds': 4.1.0
+      '@smithy/property-provider': 4.1.0
+      '@smithy/shared-ini-file-loader': 4.1.0
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
@@ -4841,6 +5208,23 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.888.0':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.888.0
+      '@aws-sdk/credential-provider-http': 3.888.0
+      '@aws-sdk/credential-provider-ini': 3.888.0
+      '@aws-sdk/credential-provider-process': 3.888.0
+      '@aws-sdk/credential-provider-sso': 3.888.0
+      '@aws-sdk/credential-provider-web-identity': 3.888.0
+      '@aws-sdk/types': 3.887.0
+      '@smithy/credential-provider-imds': 4.1.0
+      '@smithy/property-provider': 4.1.0
+      '@smithy/shared-ini-file-loader': 4.1.0
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-process@3.883.0':
     dependencies:
       '@aws-sdk/core': 3.883.0
@@ -4848,6 +5232,15 @@ snapshots:
       '@smithy/property-provider': 4.1.0
       '@smithy/shared-ini-file-loader': 4.1.0
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@aws-sdk/credential-provider-process@3.888.0':
+    dependencies:
+      '@aws-sdk/core': 3.888.0
+      '@aws-sdk/types': 3.887.0
+      '@smithy/property-provider': 4.1.0
+      '@smithy/shared-ini-file-loader': 4.1.0
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@aws-sdk/credential-provider-sso@3.883.0':
@@ -4863,6 +5256,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.888.0':
+    dependencies:
+      '@aws-sdk/client-sso': 3.888.0
+      '@aws-sdk/core': 3.888.0
+      '@aws-sdk/token-providers': 3.888.0
+      '@aws-sdk/types': 3.887.0
+      '@smithy/property-provider': 4.1.0
+      '@smithy/shared-ini-file-loader': 4.1.0
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-web-identity@3.883.0':
     dependencies:
       '@aws-sdk/core': 3.883.0
@@ -4870,6 +5276,17 @@ snapshots:
       '@aws-sdk/types': 3.862.0
       '@smithy/property-provider': 4.1.0
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.888.0':
+    dependencies:
+      '@aws-sdk/core': 3.888.0
+      '@aws-sdk/nested-clients': 3.888.0
+      '@aws-sdk/types': 3.887.0
+      '@smithy/property-provider': 4.1.0
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
@@ -4914,6 +5331,13 @@ snapshots:
       '@smithy/types': 4.4.0
       tslib: 2.6.2
 
+  '@aws-sdk/middleware-host-header@3.887.0':
+    dependencies:
+      '@aws-sdk/types': 3.887.0
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+
   '@aws-sdk/middleware-location-constraint@3.873.0':
     dependencies:
       '@aws-sdk/types': 3.862.0
@@ -4926,11 +5350,25 @@ snapshots:
       '@smithy/types': 4.4.0
       tslib: 2.6.2
 
+  '@aws-sdk/middleware-logger@3.887.0':
+    dependencies:
+      '@aws-sdk/types': 3.887.0
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+
   '@aws-sdk/middleware-recursion-detection@3.873.0':
     dependencies:
       '@aws-sdk/types': 3.862.0
       '@smithy/protocol-http': 5.2.0
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@aws-sdk/middleware-recursion-detection@3.887.0':
+    dependencies:
+      '@aws-sdk/types': 3.887.0
+      '@aws/lambda-invoke-store': 0.0.1
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@aws-sdk/middleware-sdk-s3@3.883.0':
@@ -4964,6 +5402,16 @@ snapshots:
       '@smithy/core': 3.10.0
       '@smithy/protocol-http': 5.2.0
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@aws-sdk/middleware-user-agent@3.888.0':
+    dependencies:
+      '@aws-sdk/core': 3.888.0
+      '@aws-sdk/types': 3.887.0
+      '@aws-sdk/util-endpoints': 3.887.0
+      '@smithy/core': 3.11.0
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@aws-sdk/nested-clients@3.883.0':
@@ -5009,6 +5457,49 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.888.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.888.0
+      '@aws-sdk/middleware-host-header': 3.887.0
+      '@aws-sdk/middleware-logger': 3.887.0
+      '@aws-sdk/middleware-recursion-detection': 3.887.0
+      '@aws-sdk/middleware-user-agent': 3.888.0
+      '@aws-sdk/region-config-resolver': 3.887.0
+      '@aws-sdk/types': 3.887.0
+      '@aws-sdk/util-endpoints': 3.887.0
+      '@aws-sdk/util-user-agent-browser': 3.887.0
+      '@aws-sdk/util-user-agent-node': 3.888.0
+      '@smithy/config-resolver': 4.2.1
+      '@smithy/core': 3.11.0
+      '@smithy/fetch-http-handler': 5.2.1
+      '@smithy/hash-node': 4.1.1
+      '@smithy/invalid-dependency': 4.1.1
+      '@smithy/middleware-content-length': 4.1.1
+      '@smithy/middleware-endpoint': 4.2.1
+      '@smithy/middleware-retry': 4.2.1
+      '@smithy/middleware-serde': 4.1.1
+      '@smithy/middleware-stack': 4.1.1
+      '@smithy/node-config-provider': 4.2.1
+      '@smithy/node-http-handler': 4.2.1
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/smithy-client': 4.6.1
+      '@smithy/types': 4.5.0
+      '@smithy/url-parser': 4.1.1
+      '@smithy/util-base64': 4.1.0
+      '@smithy/util-body-length-browser': 4.1.0
+      '@smithy/util-body-length-node': 4.1.0
+      '@smithy/util-defaults-mode-browser': 4.1.1
+      '@smithy/util-defaults-mode-node': 4.1.1
+      '@smithy/util-endpoints': 3.1.1
+      '@smithy/util-middleware': 4.1.1
+      '@smithy/util-retry': 4.1.1
+      '@smithy/util-utf8': 4.1.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/region-config-resolver@3.873.0':
     dependencies:
       '@aws-sdk/types': 3.862.0
@@ -5016,6 +5507,15 @@ snapshots:
       '@smithy/types': 4.4.0
       '@smithy/util-config-provider': 4.1.0
       '@smithy/util-middleware': 4.1.0
+      tslib: 2.6.2
+
+  '@aws-sdk/region-config-resolver@3.887.0':
+    dependencies:
+      '@aws-sdk/types': 3.887.0
+      '@smithy/node-config-provider': 4.2.1
+      '@smithy/types': 4.5.0
+      '@smithy/util-config-provider': 4.1.0
+      '@smithy/util-middleware': 4.1.1
       tslib: 2.6.2
 
   '@aws-sdk/s3-request-presigner@3.883.0':
@@ -5050,9 +5550,26 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/token-providers@3.888.0':
+    dependencies:
+      '@aws-sdk/core': 3.888.0
+      '@aws-sdk/nested-clients': 3.888.0
+      '@aws-sdk/types': 3.887.0
+      '@smithy/property-provider': 4.1.0
+      '@smithy/shared-ini-file-loader': 4.1.0
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/types@3.862.0':
     dependencies:
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@aws-sdk/types@3.887.0':
+    dependencies:
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@aws-sdk/util-arn-parser@3.873.0':
@@ -5065,6 +5582,14 @@ snapshots:
       '@smithy/types': 4.4.0
       '@smithy/url-parser': 4.1.0
       '@smithy/util-endpoints': 3.1.0
+      tslib: 2.6.2
+
+  '@aws-sdk/util-endpoints@3.887.0':
+    dependencies:
+      '@aws-sdk/types': 3.887.0
+      '@smithy/types': 4.5.0
+      '@smithy/url-parser': 4.1.1
+      '@smithy/util-endpoints': 3.1.1
       tslib: 2.6.2
 
   '@aws-sdk/util-format-url@3.873.0':
@@ -5085,6 +5610,13 @@ snapshots:
       bowser: 2.12.1
       tslib: 2.6.2
 
+  '@aws-sdk/util-user-agent-browser@3.887.0':
+    dependencies:
+      '@aws-sdk/types': 3.887.0
+      '@smithy/types': 4.5.0
+      bowser: 2.12.1
+      tslib: 2.6.2
+
   '@aws-sdk/util-user-agent-node@3.883.0':
     dependencies:
       '@aws-sdk/middleware-user-agent': 3.883.0
@@ -5093,10 +5625,25 @@ snapshots:
       '@smithy/types': 4.4.0
       tslib: 2.6.2
 
+  '@aws-sdk/util-user-agent-node@3.888.0':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.888.0
+      '@aws-sdk/types': 3.887.0
+      '@smithy/node-config-provider': 4.2.1
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+
   '@aws-sdk/xml-builder@3.873.0':
     dependencies:
       '@smithy/types': 4.4.0
       tslib: 2.6.2
+
+  '@aws-sdk/xml-builder@3.887.0':
+    dependencies:
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+
+  '@aws/lambda-invoke-store@0.0.1': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -5915,6 +6462,11 @@ snapshots:
       '@smithy/types': 4.4.0
       tslib: 2.6.2
 
+  '@smithy/abort-controller@4.1.1':
+    dependencies:
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+
   '@smithy/chunked-blob-reader-native@4.1.0':
     dependencies:
       '@smithy/util-base64': 4.1.0
@@ -5932,6 +6484,14 @@ snapshots:
       '@smithy/util-middleware': 4.1.0
       tslib: 2.6.2
 
+  '@smithy/config-resolver@4.2.1':
+    dependencies:
+      '@smithy/node-config-provider': 4.2.1
+      '@smithy/types': 4.5.0
+      '@smithy/util-config-provider': 4.1.0
+      '@smithy/util-middleware': 4.1.1
+      tslib: 2.6.2
+
   '@smithy/core@3.10.0':
     dependencies:
       '@smithy/middleware-serde': 4.1.0
@@ -5946,12 +6506,34 @@ snapshots:
       tslib: 2.6.2
       uuid: 9.0.1
 
+  '@smithy/core@3.11.0':
+    dependencies:
+      '@smithy/middleware-serde': 4.1.1
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/types': 4.5.0
+      '@smithy/util-base64': 4.1.0
+      '@smithy/util-body-length-browser': 4.1.0
+      '@smithy/util-middleware': 4.1.1
+      '@smithy/util-stream': 4.3.1
+      '@smithy/util-utf8': 4.1.0
+      '@types/uuid': 9.0.8
+      tslib: 2.6.2
+      uuid: 9.0.1
+
   '@smithy/credential-provider-imds@4.1.0':
     dependencies:
       '@smithy/node-config-provider': 4.2.0
       '@smithy/property-provider': 4.1.0
       '@smithy/types': 4.4.0
       '@smithy/url-parser': 4.1.0
+      tslib: 2.6.2
+
+  '@smithy/credential-provider-imds@4.1.1':
+    dependencies:
+      '@smithy/node-config-provider': 4.2.1
+      '@smithy/property-provider': 4.1.1
+      '@smithy/types': 4.5.0
+      '@smithy/url-parser': 4.1.1
       tslib: 2.6.2
 
   '@smithy/eventstream-codec@4.1.0':
@@ -5992,6 +6574,14 @@ snapshots:
       '@smithy/util-base64': 4.1.0
       tslib: 2.6.2
 
+  '@smithy/fetch-http-handler@5.2.1':
+    dependencies:
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/querystring-builder': 4.1.1
+      '@smithy/types': 4.5.0
+      '@smithy/util-base64': 4.1.0
+      tslib: 2.6.2
+
   '@smithy/hash-blob-browser@4.1.0':
     dependencies:
       '@smithy/chunked-blob-reader': 5.1.0
@@ -6006,6 +6596,13 @@ snapshots:
       '@smithy/util-utf8': 4.1.0
       tslib: 2.6.2
 
+  '@smithy/hash-node@4.1.1':
+    dependencies:
+      '@smithy/types': 4.5.0
+      '@smithy/util-buffer-from': 4.1.0
+      '@smithy/util-utf8': 4.1.0
+      tslib: 2.6.2
+
   '@smithy/hash-stream-node@4.1.0':
     dependencies:
       '@smithy/types': 4.4.0
@@ -6015,6 +6612,11 @@ snapshots:
   '@smithy/invalid-dependency@4.1.0':
     dependencies:
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@smithy/invalid-dependency@4.1.1':
+    dependencies:
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@smithy/is-array-buffer@2.2.0':
@@ -6037,6 +6639,12 @@ snapshots:
       '@smithy/types': 4.4.0
       tslib: 2.6.2
 
+  '@smithy/middleware-content-length@4.1.1':
+    dependencies:
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+
   '@smithy/middleware-endpoint@4.2.0':
     dependencies:
       '@smithy/core': 3.10.0
@@ -6046,6 +6654,17 @@ snapshots:
       '@smithy/types': 4.4.0
       '@smithy/url-parser': 4.1.0
       '@smithy/util-middleware': 4.1.0
+      tslib: 2.6.2
+
+  '@smithy/middleware-endpoint@4.2.1':
+    dependencies:
+      '@smithy/core': 3.11.0
+      '@smithy/middleware-serde': 4.1.1
+      '@smithy/node-config-provider': 4.2.1
+      '@smithy/shared-ini-file-loader': 4.1.1
+      '@smithy/types': 4.5.0
+      '@smithy/url-parser': 4.1.1
+      '@smithy/util-middleware': 4.1.1
       tslib: 2.6.2
 
   '@smithy/middleware-retry@4.2.0':
@@ -6061,10 +6680,29 @@ snapshots:
       tslib: 2.6.2
       uuid: 9.0.1
 
+  '@smithy/middleware-retry@4.2.1':
+    dependencies:
+      '@smithy/node-config-provider': 4.2.1
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/service-error-classification': 4.1.1
+      '@smithy/smithy-client': 4.6.1
+      '@smithy/types': 4.5.0
+      '@smithy/util-middleware': 4.1.1
+      '@smithy/util-retry': 4.1.1
+      '@types/uuid': 9.0.8
+      tslib: 2.6.2
+      uuid: 9.0.1
+
   '@smithy/middleware-serde@4.1.0':
     dependencies:
       '@smithy/protocol-http': 5.2.0
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@smithy/middleware-serde@4.1.1':
+    dependencies:
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@smithy/middleware-stack@4.1.0':
@@ -6072,11 +6710,23 @@ snapshots:
       '@smithy/types': 4.4.0
       tslib: 2.6.2
 
+  '@smithy/middleware-stack@4.1.1':
+    dependencies:
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+
   '@smithy/node-config-provider@4.2.0':
     dependencies:
       '@smithy/property-provider': 4.1.0
       '@smithy/shared-ini-file-loader': 4.1.0
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@smithy/node-config-provider@4.2.1':
+    dependencies:
+      '@smithy/property-provider': 4.1.1
+      '@smithy/shared-ini-file-loader': 4.1.1
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@smithy/node-http-handler@4.2.0':
@@ -6087,14 +6737,32 @@ snapshots:
       '@smithy/types': 4.4.0
       tslib: 2.6.2
 
+  '@smithy/node-http-handler@4.2.1':
+    dependencies:
+      '@smithy/abort-controller': 4.1.1
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/querystring-builder': 4.1.1
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+
   '@smithy/property-provider@4.1.0':
     dependencies:
       '@smithy/types': 4.4.0
       tslib: 2.6.2
 
+  '@smithy/property-provider@4.1.1':
+    dependencies:
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+
   '@smithy/protocol-http@5.2.0':
     dependencies:
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@smithy/protocol-http@5.2.1':
+    dependencies:
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@smithy/querystring-builder@4.1.0':
@@ -6103,18 +6771,38 @@ snapshots:
       '@smithy/util-uri-escape': 4.1.0
       tslib: 2.6.2
 
+  '@smithy/querystring-builder@4.1.1':
+    dependencies:
+      '@smithy/types': 4.5.0
+      '@smithy/util-uri-escape': 4.1.0
+      tslib: 2.6.2
+
   '@smithy/querystring-parser@4.1.0':
     dependencies:
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@smithy/querystring-parser@4.1.1':
+    dependencies:
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@smithy/service-error-classification@4.1.0':
     dependencies:
       '@smithy/types': 4.4.0
 
+  '@smithy/service-error-classification@4.1.1':
+    dependencies:
+      '@smithy/types': 4.5.0
+
   '@smithy/shared-ini-file-loader@4.1.0':
     dependencies:
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@smithy/shared-ini-file-loader@4.1.1':
+    dependencies:
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@smithy/signature-v4@5.2.0':
@@ -6138,7 +6826,21 @@ snapshots:
       '@smithy/util-stream': 4.3.0
       tslib: 2.6.2
 
+  '@smithy/smithy-client@4.6.1':
+    dependencies:
+      '@smithy/core': 3.11.0
+      '@smithy/middleware-endpoint': 4.2.1
+      '@smithy/middleware-stack': 4.1.1
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/types': 4.5.0
+      '@smithy/util-stream': 4.3.1
+      tslib: 2.6.2
+
   '@smithy/types@4.4.0':
+    dependencies:
+      tslib: 2.6.2
+
+  '@smithy/types@4.5.0':
     dependencies:
       tslib: 2.6.2
 
@@ -6146,6 +6848,12 @@ snapshots:
     dependencies:
       '@smithy/querystring-parser': 4.1.0
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@smithy/url-parser@4.1.1':
+    dependencies:
+      '@smithy/querystring-parser': 4.1.1
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@smithy/util-base64@4.1.0':
@@ -6184,6 +6892,14 @@ snapshots:
       bowser: 2.12.1
       tslib: 2.6.2
 
+  '@smithy/util-defaults-mode-browser@4.1.1':
+    dependencies:
+      '@smithy/property-provider': 4.1.1
+      '@smithy/smithy-client': 4.6.1
+      '@smithy/types': 4.5.0
+      bowser: 2.12.1
+      tslib: 2.6.2
+
   '@smithy/util-defaults-mode-node@4.1.0':
     dependencies:
       '@smithy/config-resolver': 4.2.0
@@ -6194,10 +6910,26 @@ snapshots:
       '@smithy/types': 4.4.0
       tslib: 2.6.2
 
+  '@smithy/util-defaults-mode-node@4.1.1':
+    dependencies:
+      '@smithy/config-resolver': 4.2.1
+      '@smithy/credential-provider-imds': 4.1.1
+      '@smithy/node-config-provider': 4.2.1
+      '@smithy/property-provider': 4.1.1
+      '@smithy/smithy-client': 4.6.1
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+
   '@smithy/util-endpoints@3.1.0':
     dependencies:
       '@smithy/node-config-provider': 4.2.0
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@smithy/util-endpoints@3.1.1':
+    dependencies:
+      '@smithy/node-config-provider': 4.2.1
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@smithy/util-hex-encoding@4.1.0':
@@ -6209,10 +6941,21 @@ snapshots:
       '@smithy/types': 4.4.0
       tslib: 2.6.2
 
+  '@smithy/util-middleware@4.1.1':
+    dependencies:
+      '@smithy/types': 4.5.0
+      tslib: 2.6.2
+
   '@smithy/util-retry@4.1.0':
     dependencies:
       '@smithy/service-error-classification': 4.1.0
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@smithy/util-retry@4.1.1':
+    dependencies:
+      '@smithy/service-error-classification': 4.1.1
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@smithy/util-stream@4.3.0':
@@ -6220,6 +6963,17 @@ snapshots:
       '@smithy/fetch-http-handler': 5.2.0
       '@smithy/node-http-handler': 4.2.0
       '@smithy/types': 4.4.0
+      '@smithy/util-base64': 4.1.0
+      '@smithy/util-buffer-from': 4.1.0
+      '@smithy/util-hex-encoding': 4.1.0
+      '@smithy/util-utf8': 4.1.0
+      tslib: 2.6.2
+
+  '@smithy/util-stream@4.3.1':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.2.1
+      '@smithy/node-http-handler': 4.2.1
+      '@smithy/types': 4.5.0
       '@smithy/util-base64': 4.1.0
       '@smithy/util-buffer-from': 4.1.0
       '@smithy/util-hex-encoding': 4.1.0
@@ -6244,6 +6998,12 @@ snapshots:
     dependencies:
       '@smithy/abort-controller': 4.1.0
       '@smithy/types': 4.4.0
+      tslib: 2.6.2
+
+  '@smithy/util-waiter@4.1.1':
+    dependencies:
+      '@smithy/abort-controller': 4.1.1
+      '@smithy/types': 4.5.0
       tslib: 2.6.2
 
   '@standard-schema/spec@1.0.0': {}
@@ -6365,6 +7125,13 @@ snapshots:
   '@types/node@24.2.0':
     dependencies:
       undici-types: 7.10.0
+
+  '@types/nodemailer@6.4.19':
+    dependencies:
+      '@aws-sdk/client-ses': 3.888.0
+      '@types/node': 20.19.9
+    transitivePeerDependencies:
+      - aws-crt
 
   '@types/normalize-package-data@2.4.4': {}
 


### PR DESCRIPTION
## **Summary**

- Move recipient authentication from bundle-scoped to account-scoped so a recipient can authenticate once and access all assigned bundles.
- Add enable/disable controls on recipients and bundle relationships to allow revocation without deleting data.
- Expose portal API endpoints to fetch recipient identity, list accessible bundles, browse files, and download bundles while enforcing verification, throttles, and limits.
- Perform clean, breaking schema and API changes (no feature flags or temporary compatibility) as we are still in early development.
- Keep compliance with architectural rules: database access only via `@latchflow/db`, event logging for downloads, and no hardcoded plugin types.

## **Scope**

- In scope
    - Recipient-level session model (cookie-based) independent of any bundle.
- OTP-based login (recipient-level) accepting recipientId or email, with optional future magic-link support.
    - New/updated portal API routes: `GET /portal/me`, `GET /portal/bundles`, `GET /portal/bundles/{bundleId}/objects`, `GET /portal/bundles/{bundleId}`.
    - Prisma schema updates: `isEnabled` on `Recipient`, `BundleAssignment`, `Bundle`, and `BundleObject` (default true), plus indexes.
    - Refactor current OTP/session tables from bundle-scoped to recipient-scoped (breaking change; no compatibility layer).
    - Enforcement of per-assignment limits (`maxDownloads`, `cooldownSeconds`) and verification (`verificationType`, `verificationMet`) at download time.
    - Update OpenAPI, generated API types, and core middleware for recipient auth.
- Out of scope (for this story)
    - UI applications (admin and portal frontends) — only API and backend changes in this repo.
    - Email/SMS delivery providers beyond existing dev/local setup (MailHog).
    - Public link publishing (remains via `release_bundle` action only).

## **To-Do**

- Data model (Prisma)
    - [x] Add `isEnabled Boolean @default(true)` to `Recipient` with `@@index([isEnabled])`.
    - [x] Add `isEnabled Boolean @default(true)` to `BundleAssignment` with `@@index([bundleId, recipientId, isEnabled])`.
    - [x] Add `isEnabled Boolean @default(true)` to `Bundle` and `BundleObject` (index `BundleObject(bundleId, isEnabled, sortOrder)`).
    - [x] Refactor `RecipientSession`: remove `bundleId`, keep `recipientId`, `jti`, `expiresAt`, `revokedAt`, `ip`, `userAgent`.
    - [x] Refactor `RecipientOtp`: remove `bundleId`; key by `recipientId` only (rate-limit per-IP and per-recipient).
    - [x] Write a breaking migration; drop obsolete columns and backfill defaults where needed.
- Core service (routes + middleware)
    - [x] Update `requireRecipient` middleware to stop enforcing bundle by default; for bundle-scoped routes, validate assignment membership for the `bundleId`.
    - [x] Replace `/auth/recipient/start` + `/auth/recipient/verify` bodies to accept `{ recipientId }` or `{ email }`; remove `bundleId` requirement.
    - [x] Add `/portal/auth/otp/resend` that accepts `{ recipientId }` or `{ email }`.
    - [x] Implement `GET /portal/me` returning `{ recipient, bundles[] }`, filtering by all enable flags and active assignments.
    - [x] Implement `GET /portal/bundles` paginated list of accessible bundles with same filters.
    - [x] Implement `GET /portal/bundles/{bundleId}/objects` (bundleScoped) honoring `BundleObject.isEnabled`.
    - [x] Implement `GET /portal/bundles/{bundleId}` download (bundleScoped); enforce `maxDownloads`, `cooldownSeconds`, and `verificationType`/`verificationMet`.
    - [x] Ensure every download creates a `DownloadEvent` (bundle-level event; `fileId` null for archive, or per-file when streaming individual files if applicable).
- OpenAPI and SDKs
    - [x] Update `packages/core/openapi` for new/changed recipient auth and portal routes.
- Tests
    - [x] Unit: `require-recipient` middleware for recipient-only and bundle-scoped flows.
    - [x] Unit: recipient auth routes (start/verify/resend) with rate limits and invalid cases (id and email).
    - [x] Integration: `GET /portal/me` and `GET /portal/bundles` filters (flags, disabled assignment, disabled bundle/object).
    - [x] Integration: download enforcement (`maxDownloads`, `cooldownSeconds`, `verificationType`).
    - [x] E2E: recipient portal happy path with Testcontainers (streams bundle; logs DownloadEvent).
    - [x] Ensure all tests run under `pnpm -r test` (unit/integration) and E2E under `pnpm -F core test:e2e`.

## **DoD**

- [x] Recipients can authenticate once and fetch `GET /portal/me` showing their identity and at least one bundle when assigned/enabled.
- [x] `GET /portal/bundles` returns only bundles where Recipient, Bundle, and BundleAssignment are all `isEnabled`.
- [x] Download honors `maxDownloads` and `cooldownSeconds`; attempts beyond limits return 429/403 with clear error.
- [x] Verification enforced according to `verificationType`; unverified assignments cannot download; verified can.
- [x] Each download creates a `DownloadEvent` row with correct association to the `BundleAssignment` and request metadata.
- [x] New `isEnabled` fields exist on `Recipient`, `BundleAssignment`, `Bundle`, and `BundleObject` with indexes.
- [x] Recipient-level OTP flow replaces the old bundle-scoped flow (breaking change documented); endpoints and tests updated accordingly.
- [x] All DB access goes through `@latchflow/db` in the core service (no direct DB access from non-core code).

## **Follow-ups**

- Regenerate API types once OpenAPI is bundled: `pnpm oas:bundle && pnpm oas:types`.
- Update README/docs to reflect recipient account-scoped model and the breaking changes.
- Consider additional DB indexes for analytics and throttling, e.g., `DownloadEvent(bundleAssignmentId, downloadedAt)`.
- Document rate limiter limitations (in-memory, per-process) and plan a distributed limiter (e.g., Redis) for production.
