### PR TITLE
Bundles

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,74 @@
+# Latchflow Architecture
+
+This document explains the runtime shape and key flows with an emphasis on the portal auth model, assignment enforcement, and the bundle auto‑rebuild pipeline.
+
+## Portal Auth (Account‑Scoped)
+
+- Recipients authenticate via OTP and establish a cookie session that is not tied to a specific bundle.
+- After login, authorization checks are done per request:
+  - Lists only show enabled bundles and files the recipient is assigned to.
+  - Downloads enforce limits atomically (see below).
+
+### Endpoints
+- `GET /portal/me` — identity and accessible bundles (`{ bundleId, name }`).
+- `GET /portal/bundles` — cursor‑paginated view over enabled assignments.
+- `GET /portal/bundles/{bundleId}/objects` — enabled files within the bundle.
+- `GET /portal/bundles/{bundleId}` — stream zipped bundle artifact.
+- `GET /portal/assignments` — per‑assignment summary (downloads used/remaining, cooldown timing).
+
+### Assignment Enforcement
+- Every download runs inside an atomic guard:
+  - Counts used downloads, compares against `maxDownloads`.
+  - Checks `lastDownloadAt + cooldownSeconds` against now.
+  - Inserts a `DownloadEvent` and updates `lastDownloadAt` when allowed.
+
+### Enable/Disable Flags
+- The following flags control access without data deletion:
+  - `Recipient.isEnabled`
+  - `Bundle.isEnabled`
+  - `BundleAssignment.isEnabled`
+  - `BundleObject.isEnabled`
+
+## Bundle Artifacts & Auto‑Rebuilds
+
+### Storage & ETags
+- Bundles are stored as zip archives in object storage.
+- Downloads prefer the storage‑native `ETag`; fallback to the DB checksum (sha256) if the HEAD call fails.
+
+### Composition Digest
+- `Bundle.bundleDigest` stores a sha256 over ordered contents `{ fileId, file.contentHash, path, required, sortOrder }`.
+- Rebuilds skip when the newly computed digest matches the stored one (unless `force` is used).
+
+### Rebuilder
+- In‑memory scheduler per process:
+  - Debounces rebuild requests per bundle (2s by default).
+  - Coalesces concurrent requests and guarantees one build flight at a time.
+  - Records last result (`built` or `skipped`).
+- Triggers:
+  - File content changes (upload or commit) locate referencing bundles and enqueue rebuilds.
+  - Lazy backstop: portal routes compute digest and enqueue when drift is detected; serving is never blocked.
+  - BundleObject CRUD/reorder hooks will enqueue directly (to be added along with admin endpoints).
+
+### Manual Admin Control
+- `POST /admin/bundles/{bundleId}/build` — enqueues an async build; supports `{ force: boolean }`.
+- `GET /admin/bundles/{bundleId}/build/status` — returns `idle|queued|running`, current pointers, and last result.
+
+### Atomic Pointer Update
+- Builds stream files into a deterministic zip, upload via storage service, then atomically update:
+  - `Bundle.storagePath` to the new object key
+  - `Bundle.checksum` to the storage ETag (fallback sha256)
+  - `Bundle.bundleDigest` to the computed digest
+- Old artifacts continue to serve until the pointer swap completes.
+
+## Admin Assignment Summaries
+
+- Admin views expose the same status calculations used by the portal:
+  - `GET /admin/bundles/{bundleId}/assignments`
+  - `GET /admin/recipients/{recipientId}/assignments`
+- Items include: downloads used/remaining, cooldown timing, enable flags, and labels.
+
+## Plugin Registry (Overview)
+
+- Triggers and actions are declared by installed plugins and registered at startup.
+- The core runtime orchestrates trigger → action pipelines; no hard‑coded types.
+

--- a/packages/core/openapi/components/schemas/AdminAssignmentSummary.yaml
+++ b/packages/core/openapi/components/schemas/AdminAssignmentSummary.yaml
@@ -1,0 +1,36 @@
+type: object
+description: Assignment summary for admin views
+properties:
+  assignmentId: { type: string, format: uuid }
+  bundleId: { type: string, format: uuid }
+  bundleName: { type: string }
+  recipientId: { type: string, format: uuid }
+  recipientEmail: { type: string, format: email }
+  recipientName:
+    oneOf:
+      - { type: string }
+      - { type: 'null' }
+  isEnabled: { type: boolean }
+  maxDownloads:
+    oneOf:
+      - { type: integer }
+      - { type: 'null' }
+  downloadsUsed: { type: integer }
+  downloadsRemaining:
+    oneOf:
+      - { type: integer }
+      - { type: 'null' }
+  cooldownSeconds:
+    oneOf:
+      - { type: integer }
+      - { type: 'null' }
+  lastDownloadAt:
+    oneOf:
+      - { type: string, format: date-time }
+      - { type: 'null' }
+  nextAvailableAt:
+    oneOf:
+      - { type: string, format: date-time }
+      - { type: 'null' }
+  cooldownRemainingSeconds: { type: integer }
+required: [assignmentId, bundleId, bundleName, recipientId, recipientEmail, isEnabled, downloadsUsed, cooldownRemainingSeconds]

--- a/packages/core/openapi/components/schemas/AssignmentSummary.yaml
+++ b/packages/core/openapi/components/schemas/AssignmentSummary.yaml
@@ -1,0 +1,28 @@
+type: object
+description: Per-assignment status summary for a recipient
+properties:
+  bundleId: { type: string, format: uuid }
+  name: { type: string }
+  maxDownloads:
+    oneOf:
+      - { type: integer }
+      - { type: 'null' }
+  downloadsUsed: { type: integer }
+  downloadsRemaining:
+    oneOf:
+      - { type: integer }
+      - { type: 'null' }
+  cooldownSeconds:
+    oneOf:
+      - { type: integer }
+      - { type: 'null' }
+  lastDownloadAt:
+    oneOf:
+      - { type: string, format: date-time }
+      - { type: 'null' }
+  nextAvailableAt:
+    oneOf:
+      - { type: string, format: date-time }
+      - { type: 'null' }
+  cooldownRemainingSeconds: { type: integer }
+required: [bundleId, name, downloadsUsed, cooldownRemainingSeconds]

--- a/packages/core/openapi/components/schemas/BuildStatus.yaml
+++ b/packages/core/openapi/components/schemas/BuildStatus.yaml
@@ -1,0 +1,23 @@
+type: object
+description: Bundle build status
+properties:
+  status:
+    type: string
+    enum: [idle, queued, running]
+  bundleId: { type: string, format: uuid }
+  bundleDigest: { type: string }
+  storagePath: { type: string }
+  checksum: { type: string }
+  updatedAt:
+    oneOf:
+      - { type: string, format: date-time }
+      - { type: 'null' }
+  last:
+    type: object
+    properties:
+      when: { type: string, format: date-time }
+      status:
+        type: string
+        enum: [built, skipped]
+      error: { type: string }
+    required: [when, status]

--- a/packages/core/openapi/components/schemas/Bundle.yaml
+++ b/packages/core/openapi/components/schemas/Bundle.yaml
@@ -4,7 +4,10 @@ properties:
   name: { type: string }
   storagePath: { type: string }
   checksum: { type: string }
-  description: { type: string, nullable: true }
+  description:
+    oneOf:
+      - { type: string }
+      - { type: 'null' }
   createdAt: { type: string, format: date-time }
   updatedAt: { type: string, format: date-time }
 required: [id, name, storagePath, checksum, createdAt]

--- a/packages/core/openapi/components/schemas/Pipeline.yaml
+++ b/packages/core/openapi/components/schemas/Pipeline.yaml
@@ -2,7 +2,10 @@ type: object
 properties:
   id: { type: string, format: uuid }
   name: { type: string }
-  description: { type: string, nullable: true }
+  description:
+    oneOf:
+      - { type: string }
+      - { type: 'null' }
   isEnabled: { type: boolean }
   createdAt: { type: string, format: date-time }
   updatedAt: { type: string, format: date-time }

--- a/packages/core/openapi/openapi.yaml
+++ b/packages/core/openapi/openapi.yaml
@@ -160,6 +160,17 @@ paths:
     $ref: ./paths/portal.yaml#/portal_bundle_download
   /portal/auth/otp/resend:
     $ref: ./paths/portal.yaml#/portal_otp_resend
+  /portal/assignments:
+    $ref: ./paths/portal.yaml#/portal_assignments
+
+  /admin/bundles/{bundleId}/assignments:
+    $ref: ./paths/admin-assignments.yaml#/bundle_assignments
+  /admin/recipients/{recipientId}/assignments:
+    $ref: ./paths/admin-assignments.yaml#/recipient_assignments
+  /admin/bundles/{bundleId}/build:
+    $ref: ./paths/admin-bundle-build.yaml#/bundle_build
+  /admin/bundles/{bundleId}/build/status:
+    $ref: ./paths/admin-bundle-build.yaml#/bundle_build_status
 
   /plugins:
     $ref: ./paths/plugins.yaml#/plugins
@@ -237,6 +248,9 @@ components:
     DeviceStartResponse: { $ref: ./components/schemas/DeviceStartResponse.yaml }
     DevicePollPending: { $ref: ./components/schemas/DevicePollPending.yaml }
     DevicePollSuccess: { $ref: ./components/schemas/DevicePollSuccess.yaml }
+    AssignmentSummary: { $ref: ./components/schemas/AssignmentSummary.yaml }
+    AdminAssignmentSummary: { $ref: ./components/schemas/AdminAssignmentSummary.yaml }
+    BuildStatus: { $ref: ./components/schemas/BuildStatus.yaml }
   parameters:
     Cursor: { $ref: ./components/parameters/Cursor.yaml }
     Limit: { $ref: ./components/parameters/Limit.yaml }

--- a/packages/core/openapi/paths/admin-assignments.yaml
+++ b/packages/core/openapi/paths/admin-assignments.yaml
@@ -1,0 +1,58 @@
+bundle_assignments:
+  get:
+    summary: List assignment summaries for a bundle
+    operationId: listBundleAssignments
+    tags: [Bundles]
+    security:
+      - bearer: []
+      - cookieAdmin: []
+    parameters:
+      - in: path
+        name: bundleId
+        required: true
+        schema: { type: string, format: uuid }
+      - $ref: ../components/parameters/Limit.yaml
+    responses:
+      '200':
+        description: Assignment summaries
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items: { $ref: ../components/schemas/AdminAssignmentSummary.yaml }
+              required: [items]
+      '401': { $ref: ../components/responses/Unauthorized.yaml }
+      '403': { $ref: ../components/responses/Forbidden.yaml }
+
+recipient_assignments:
+  get:
+    summary: List assignment summaries for a recipient
+    operationId: listRecipientAssignments
+    tags: [Recipients]
+    security:
+      - bearer: []
+      - cookieAdmin: []
+    parameters:
+      - in: path
+        name: recipientId
+        required: true
+        schema: { type: string, format: uuid }
+      - $ref: ../components/parameters/Limit.yaml
+    responses:
+      '200':
+        description: Assignment summaries
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items: { $ref: ../components/schemas/AdminAssignmentSummary.yaml }
+              required: [items]
+      '401': { $ref: ../components/responses/Unauthorized.yaml }
+      '403': { $ref: ../components/responses/Forbidden.yaml }
+

--- a/packages/core/openapi/paths/admin-bundle-build.yaml
+++ b/packages/core/openapi/paths/admin-bundle-build.yaml
@@ -1,0 +1,59 @@
+bundle_build:
+  post:
+    summary: Enqueue bundle rebuild
+    operationId: enqueueBundleBuild
+    tags: [Bundles]
+    security:
+      - bearer: []
+      - cookieAdmin: []
+    parameters:
+      - in: path
+        name: bundleId
+        required: true
+        schema: { type: string, format: uuid }
+    requestBody:
+      required: false
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              force: { type: boolean }
+    responses:
+      '202':
+        description: Build enqueued
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum: [queued]
+              required: [status]
+      '401': { $ref: ../components/responses/Unauthorized.yaml }
+      '403': { $ref: ../components/responses/Forbidden.yaml }
+
+bundle_build_status:
+  get:
+    summary: Get bundle build status
+    operationId: getBundleBuildStatus
+    tags: [Bundles]
+    security:
+      - bearer: []
+      - cookieAdmin: []
+    parameters:
+      - in: path
+        name: bundleId
+        required: true
+        schema: { type: string, format: uuid }
+    responses:
+      '200':
+        description: Build status
+        content:
+          application/json:
+            schema: { $ref: ../components/schemas/BuildStatus.yaml }
+      '401': { $ref: ../components/responses/Unauthorized.yaml }
+      '403': { $ref: ../components/responses/Forbidden.yaml }
+      '404': { $ref: ../components/responses/NotFound.yaml }
+

--- a/packages/core/openapi/paths/auth/recipient.yaml
+++ b/packages/core/openapi/paths/auth/recipient.yaml
@@ -44,20 +44,15 @@ recipient_verify:
       content:
         application/json:
           schema:
-            allOf:
-              - oneOf:
-                  - type: object
-                    properties:
-                      recipientId: { type: string }
-                    required: [recipientId]
-                  - type: object
-                    properties:
-                      email: { type: string, format: email }
-                    required: [email]
-              - type: object
-                properties:
-                  otp: { type: string }
-                required: [otp]
+            type: object
+            properties:
+              recipientId: { type: string }
+              email: { type: string, format: email }
+              otp: { type: string }
+            required: [otp]
+            oneOf:
+              - required: [recipientId, otp]
+              - required: [email, otp]
           examples:
             example:
               value:

--- a/packages/core/openapi/paths/portal.yaml
+++ b/packages/core/openapi/paths/portal.yaml
@@ -123,3 +123,24 @@ portal_otp_resend:
       '204': { description: Sent }
       '429': { $ref: ../components/responses/RateLimited.yaml }
       '400': { $ref: ../components/responses/ValidationError.yaml }
+
+portal_assignments:
+  get:
+    summary: List per-assignment status for the current recipient
+    operationId: listPortalAssignments
+    tags: [Portal]
+    security:
+      - cookieRecipient: []
+    responses:
+      '200':
+        description: Assignment summaries
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items: { $ref: ../components/schemas/AssignmentSummary.yaml }
+              required: [items]
+      '401': { $ref: ../components/responses/Unauthorized.yaml }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,8 @@
     "pino": "^9.3.2",
     "pino-http": "^9.0.0",
     "nodemailer": "^6.9.14",
-    "zod": "^3.23.0"
+    "zod": "^3.23.0",
+    "zip-stream": "^6.0.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/packages/core/src/authz/policy.ts
+++ b/packages/core/src/authz/policy.ts
@@ -14,7 +14,17 @@ export const POLICY: Record<RouteSignature, PolicyEntry> = {
   // Admin stubs (can be refined as endpoints are implemented)
   "GET /admin/actions": { action: "read", resource: "action_def", v1AllowExecutor: true },
   "GET /admin/bundles": { action: "read", resource: "bundle", v1AllowExecutor: true },
+  "GET /admin/bundles/:bundleId/assignments": {
+    action: "read",
+    resource: "bundle",
+    v1AllowExecutor: true,
+  },
   "GET /admin/recipients": { action: "read", resource: "recipient", v1AllowExecutor: true },
+  "GET /admin/recipients/:recipientId/assignments": {
+    action: "read",
+    resource: "recipient",
+    v1AllowExecutor: true,
+  },
   "GET /admin/triggers": { action: "read", resource: "trigger_def", v1AllowExecutor: true },
 
   // Files

--- a/packages/core/src/authz/policy.ts
+++ b/packages/core/src/authz/policy.ts
@@ -14,6 +14,12 @@ export const POLICY: Record<RouteSignature, PolicyEntry> = {
   // Admin stubs (can be refined as endpoints are implemented)
   "GET /admin/actions": { action: "read", resource: "action_def", v1AllowExecutor: true },
   "GET /admin/bundles": { action: "read", resource: "bundle", v1AllowExecutor: true },
+  "POST /admin/bundles/:bundleId/build": { action: "update", resource: "bundle" },
+  "GET /admin/bundles/:bundleId/build/status": {
+    action: "read",
+    resource: "bundle",
+    v1AllowExecutor: true,
+  },
   "GET /admin/bundles/:bundleId/assignments": {
     action: "read",
     resource: "bundle",

--- a/packages/core/src/bundles/builder.test.ts
+++ b/packages/core/src/bundles/builder.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Readable } from "node:stream";
+import { buildBundleArtifact } from "./builder.js";
+
+// Mock zip-stream with deterministic concatenation of entry data
+vi.mock("zip-stream", () => {
+  class FakeZip {
+    private chunks: Buffer[] = [];
+    pipe(dst: any) {
+      this._dst = dst;
+    }
+    entry(src: any, _opts: any, cb: (err: Error | null) => void) {
+      const collect = async () => {
+        if (Buffer.isBuffer(src)) this.chunks.push(Buffer.from(src));
+        else
+          await new Promise<void>((resolve) => {
+            src.on("data", (b: Buffer) => this.chunks.push(Buffer.from(b)));
+            src.on("end", resolve);
+          });
+        cb(null);
+      };
+      void collect();
+    }
+    finish(cb: () => void) {
+      const buf = Buffer.concat(this.chunks);
+      if (this._dst?.write) this._dst.write(buf);
+      if (this._dst?.end) this._dst.end();
+      cb();
+    }
+  }
+  return { default: FakeZip } as any;
+});
+
+describe("buildBundleArtifact", () => {
+  const db: any = {
+    bundle: {
+      findUnique: vi.fn(async () => ({ id: "B1", name: "B", bundleDigest: "prev" })),
+      update: vi.fn(async () => ({})),
+    },
+    bundleObject: {
+      findMany: vi.fn(async () => [
+        {
+          fileId: "F1",
+          path: "a.txt",
+          sortOrder: 1,
+          file: { id: "F1", key: "k1", storageKey: "s1" },
+        },
+        { fileId: "F2", path: null, sortOrder: 2, file: { id: "F2", key: "k2", storageKey: "s2" } },
+      ]),
+    },
+  };
+
+  function makeStorage() {
+    const puts: Buffer[] = [];
+    const storage = {
+      getFileStream: vi.fn(async (key: string) => Readable.from(Buffer.from(`data:${key}`))),
+      putFile: vi.fn(async ({ body }: { body: Buffer }) => {
+        puts.push(Buffer.from(body));
+        return {
+          storageKey: "objects/sha256/zz/zz/zip",
+          size: body.length,
+          sha256: "ziphash",
+          storageEtag: "zip-etag",
+        };
+      }),
+    } as any;
+    return { storage, puts };
+  }
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    db.bundle.findUnique.mockClear();
+    db.bundle.update.mockClear();
+    db.bundleObject.findMany.mockClear();
+  });
+
+  it("produces deterministic zip content across runs", async () => {
+    const { storage, puts } = makeStorage();
+    const res1 = await buildBundleArtifact(db, storage, "B1", { force: true });
+    expect(res1.status).toBe("built");
+    const first = Buffer.from(puts[0]);
+    // Run again with force to avoid skip-by-digest
+    const res2 = await buildBundleArtifact(db, storage, "B1", { force: true });
+    expect(res2.status).toBe("built");
+    const second = Buffer.from(puts[1]);
+    expect(first.equals(second)).toBe(true);
+  });
+});

--- a/packages/core/src/bundles/builder.ts
+++ b/packages/core/src/bundles/builder.ts
@@ -1,4 +1,4 @@
-import { PassThrough, Readable } from "node:stream";
+import { PassThrough } from "node:stream";
 import type { DbClient } from "../db/db.js";
 import type { StorageService } from "../storage/service.js";
 import { computeBundleDigest } from "./digest.js";
@@ -85,7 +85,7 @@ export async function buildBundleArtifact(
     if (!f || !f.storageKey) continue; // skip missing
     const name = row.path ?? f.key ?? f.id;
     // Stream file into zip entry
-    const fileStream: Readable = await storage.getFileStream(f.storageKey);
+    const fileStream: NodeJS.ReadableStream = await storage.getFileStream(f.storageKey);
     await new Promise<void>((resolve, reject) => {
       zip.entry(fileStream, { name, store: true, date: new Date(0) }, (err: Error | null) => {
         if (err) reject(err);

--- a/packages/core/src/bundles/builder.ts
+++ b/packages/core/src/bundles/builder.ts
@@ -1,0 +1,119 @@
+import { PassThrough, Readable } from "node:stream";
+import type { DbClient } from "../db/db.js";
+import type { StorageService } from "../storage/service.js";
+import { computeBundleDigest } from "./digest.js";
+
+type ZipLike = {
+  pipe(dst: NodeJS.WritableStream): void;
+  entry(
+    source: NodeJS.ReadableStream | Buffer,
+    options: { name: string; store?: boolean; date?: Date },
+    cb: (err: Error | null) => void,
+  ): void;
+  finish(cb: () => void): void;
+};
+
+async function createZip(): Promise<ZipLike> {
+  const mod = (await import("zip-stream")) as unknown;
+  // CJS default export or constructor
+  const Ctor = ((mod as { default?: new () => ZipLike }).default ??
+    (mod as unknown as new () => ZipLike)) as (new () => ZipLike) | undefined;
+  if (!Ctor) throw new Error("zip-stream not available");
+  return new Ctor();
+}
+
+export type BuildResult =
+  | { status: "skipped"; reason: "unchanged" }
+  | {
+      status: "built";
+      storageKey: string;
+      checksum: string;
+      size: number;
+      digest: string;
+    };
+
+export async function buildBundleArtifact(
+  db: DbClient,
+  storage: StorageService,
+  bundleId: string,
+  opts: { force?: boolean } = {},
+): Promise<BuildResult> {
+  const b = await db.bundle.findUnique({
+    where: { id: bundleId },
+    select: { id: true, name: true, bundleDigest: true },
+  });
+  if (!b) throw new Error("Bundle not found");
+
+  const { digest } = await computeBundleDigest(db, bundleId);
+  if (!opts.force && b.bundleDigest && b.bundleDigest === digest) {
+    return { status: "skipped", reason: "unchanged" } as const;
+  }
+
+  // Build deterministic zip in-memory. For now use store=true (no compression)
+  // to keep output deterministic across environments.
+  const zip = await createZip();
+  const out = new PassThrough();
+  const buffers: Buffer[] = [];
+  const collecting = new Promise<Buffer>((resolve, reject) => {
+    out.on("data", (c: Buffer) => buffers.push(Buffer.from(c)));
+    out.on("end", () => resolve(Buffer.concat(buffers)));
+    out.on("error", reject);
+  });
+  zip.pipe(out);
+
+  // Resolve file entry name using BundleObject.path || File.key || File.id
+  // Fetch file keys/storage keys in the same order
+  type Row = {
+    fileId: string;
+    path: string | null;
+    sortOrder: number;
+    file: { id: string; key: string; storageKey: string } | null;
+  };
+  const rows = (await db.bundleObject.findMany({
+    where: { bundleId, isEnabled: true },
+    orderBy: [{ sortOrder: "asc" }, { id: "asc" }],
+    select: {
+      fileId: true,
+      path: true,
+      sortOrder: true,
+      file: { select: { id: true, key: true, storageKey: true } },
+    },
+  })) as unknown as Row[];
+
+  for (const row of rows) {
+    const f = row.file;
+    if (!f || !f.storageKey) continue; // skip missing
+    const name = row.path ?? f.key ?? f.id;
+    // Stream file into zip entry
+    const fileStream: Readable = await storage.getFileStream(f.storageKey);
+    await new Promise<void>((resolve, reject) => {
+      zip.entry(fileStream, { name, store: true, date: new Date(0) }, (err: Error | null) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+
+  await new Promise<void>((resolve) => zip.finish(() => resolve()));
+  const zipBuffer = await collecting;
+
+  const put = await storage.putFile({ body: zipBuffer, contentType: "application/zip" });
+
+  // Atomic pointer update + digest set
+  await db.bundle.update({
+    where: { id: bundleId },
+    data: {
+      storagePath: put.storageKey,
+      checksum: put.storageEtag ?? put.sha256,
+      bundleDigest: digest,
+    },
+  });
+
+  return {
+    status: "built",
+    storageKey: put.storageKey,
+    checksum: put.storageEtag ?? put.sha256,
+    size: put.size,
+    digest,
+  } as const;
+}

--- a/packages/core/src/bundles/digest.test.ts
+++ b/packages/core/src/bundles/digest.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { computeBundleDigest } from "./digest.js";
+
+describe("computeBundleDigest", () => {
+  it("produces stable digest over ordered items", async () => {
+    const db = {
+      bundle: {
+        findUnique: async () => ({
+          id: "B1",
+          bundleObjects: [
+            {
+              fileId: "F1",
+              path: "a.txt",
+              required: true,
+              sortOrder: 1,
+              file: { id: "F1", contentHash: "h1" },
+            },
+            {
+              fileId: "F2",
+              path: null,
+              required: false,
+              sortOrder: 2,
+              file: { id: "F2", contentHash: "h2" },
+            },
+          ],
+        }),
+      },
+    } as any;
+    const a = await computeBundleDigest(db, "B1");
+    const b = await computeBundleDigest(db, "B1");
+    expect(a.digest).toBe(b.digest);
+    // Changing order changes digest
+    const db2 = {
+      bundle: {
+        findUnique: async () => ({
+          id: "B1",
+          bundleObjects: [
+            {
+              fileId: "F2",
+              path: null,
+              required: false,
+              sortOrder: 1,
+              file: { id: "F2", contentHash: "h2" },
+            },
+            {
+              fileId: "F1",
+              path: "a.txt",
+              required: true,
+              sortOrder: 2,
+              file: { id: "F1", contentHash: "h1" },
+            },
+          ],
+        }),
+      },
+    } as any;
+    const c = await computeBundleDigest(db2, "B1");
+    expect(c.digest).not.toBe(a.digest);
+  });
+});

--- a/packages/core/src/bundles/digest.ts
+++ b/packages/core/src/bundles/digest.ts
@@ -1,0 +1,67 @@
+import { createHash } from "node:crypto";
+import type { DbClient } from "../db/db.js";
+
+export type BundleDigestItem = {
+  fileId: string;
+  contentHash: string;
+  path: string | null;
+  required: boolean;
+  sortOrder: number;
+};
+
+function sha256Hex(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+/**
+ * Computes a stable digest for a bundle's composition over ordered
+ * { fileId, file.contentHash, path, required, sortOrder } items.
+ */
+export async function computeBundleDigest(
+  db: DbClient,
+  bundleId: string,
+): Promise<{
+  digest: string;
+  items: BundleDigestItem[];
+}> {
+  const rec = await db.bundle.findUnique({
+    where: { id: bundleId },
+    select: {
+      id: true,
+      bundleObjects: {
+        where: { isEnabled: true },
+        orderBy: [{ sortOrder: "asc" }, { id: "asc" }],
+        select: {
+          fileId: true,
+          path: true,
+          required: true,
+          sortOrder: true,
+          file: { select: { id: true, contentHash: true } },
+        },
+      },
+    },
+  });
+  if (!rec) return { digest: "", items: [] };
+  const items: BundleDigestItem[] = [];
+  for (const bo of rec.bundleObjects) {
+    const ch = bo.file?.contentHash ?? "";
+    items.push({
+      fileId: bo.fileId,
+      contentHash: ch,
+      path: bo.path ?? null,
+      required: Boolean(bo.required),
+      sortOrder: Number(bo.sortOrder ?? 0),
+    });
+  }
+  // Deterministic JSON: keys in fixed order
+  const serialized = JSON.stringify(
+    items.map((i) => ({
+      fileId: i.fileId,
+      contentHash: i.contentHash,
+      path: i.path,
+      required: i.required,
+      sortOrder: i.sortOrder,
+    })),
+  );
+  return { digest: sha256Hex(serialized), items };
+}

--- a/packages/core/src/bundles/scheduler.ts
+++ b/packages/core/src/bundles/scheduler.ts
@@ -1,0 +1,94 @@
+import type { DbClient } from "../db/db.js";
+import type { StorageService } from "../storage/service.js";
+import { buildBundleArtifact } from "./builder.js";
+
+export type BundleRebuildScheduler = ReturnType<typeof createBundleRebuildScheduler>;
+
+export function createBundleRebuildScheduler(deps: {
+  db: DbClient;
+  storage: StorageService;
+  debounceMs?: number;
+}) {
+  const db = deps.db;
+  const storage = deps.storage;
+  const debounceMs = typeof deps.debounceMs === "number" ? deps.debounceMs : 2000;
+  const timers = new Map<string, NodeJS.Timeout>();
+  const running = new Set<string>();
+  const queued = new Set<string>();
+  const forceFlags = new Set<string>();
+  const last: Record<string, { when: Date; status: "built" | "skipped"; error?: string }> = {};
+
+  async function run(bundleId: string) {
+    if (running.has(bundleId)) {
+      queued.add(bundleId);
+      return;
+    }
+    running.add(bundleId);
+    try {
+      const force = forceFlags.has(bundleId);
+      forceFlags.delete(bundleId);
+      const res = await buildBundleArtifact(db, storage, bundleId, { force }).catch((e: Error) => {
+        last[bundleId] = { when: new Date(), status: "skipped", error: e.message };
+        return null;
+      });
+      if (res) {
+        if (res.status === "built") last[bundleId] = { when: new Date(), status: "built" };
+        else last[bundleId] = { when: new Date(), status: "skipped" };
+      }
+    } finally {
+      running.delete(bundleId);
+      if (queued.has(bundleId)) {
+        queued.delete(bundleId);
+        schedule(bundleId);
+      }
+    }
+  }
+
+  function schedule(bundleId: string, opts?: { force?: boolean }) {
+    // Debounce per bundle
+    const existing = timers.get(bundleId);
+    if (existing) clearTimeout(existing);
+    if (opts?.force) forceFlags.add(bundleId);
+    const t = setTimeout(() => {
+      timers.delete(bundleId);
+      void run(bundleId);
+    }, debounceMs);
+    timers.set(bundleId, t);
+  }
+
+  async function scheduleForFiles(fileIds: string[], opts?: { force?: boolean }) {
+    if (fileIds.length === 0) return;
+    const bos = await db.bundleObject.findMany({
+      where: { fileId: { in: fileIds } },
+      select: { bundleId: true },
+    });
+    const bundleIds = Array.from(new Set(bos.map((x) => x.bundleId))).filter(Boolean);
+    for (const bid of bundleIds) schedule(bid, opts);
+  }
+
+  function getStatus(bundleId: string): {
+    state: "idle" | "queued" | "running";
+    last?: { when: string; status: "built" | "skipped"; error?: string };
+  } {
+    const state = running.has(bundleId) ? "running" : timers.has(bundleId) ? "queued" : "idle";
+    const l = last[bundleId];
+    return {
+      state,
+      ...(l
+        ? {
+            last: {
+              when: l.when.toISOString(),
+              status: l.status,
+              ...(l.error ? { error: l.error } : {}),
+            },
+          }
+        : {}),
+    };
+  }
+
+  return {
+    schedule,
+    scheduleForFiles,
+    getStatus,
+  };
+}

--- a/packages/core/src/dto/assignment.ts
+++ b/packages/core/src/dto/assignment.ts
@@ -1,0 +1,50 @@
+// Assignment summary DTO and mapper
+
+export type AssignmentSummary = {
+  bundleId: string;
+  name: string;
+  maxDownloads: number | null;
+  downloadsUsed: number;
+  downloadsRemaining: number | null;
+  cooldownSeconds: number | null;
+  lastDownloadAt: string | null;
+  nextAvailableAt: string | null;
+  cooldownRemainingSeconds: number;
+};
+
+export type AssignmentRowForSummary = {
+  id: string;
+  bundleId: string;
+  maxDownloads: number | null;
+  cooldownSeconds: number | null;
+  lastDownloadAt: Date | null;
+  bundle?: { id: string; name: string } | null;
+};
+
+export function toAssignmentSummary(
+  row: AssignmentRowForSummary,
+  downloadsUsed: number,
+  now: Date = new Date(),
+): AssignmentSummary {
+  const name = row.bundle?.name ?? "";
+  const bundleId = row.bundle?.id ?? row.bundleId;
+  const remaining = row.maxDownloads != null ? Math.max(0, row.maxDownloads - downloadsUsed) : null;
+  const nextAvailableAtDate =
+    row.cooldownSeconds != null && row.lastDownloadAt
+      ? new Date(row.lastDownloadAt.getTime() + row.cooldownSeconds * 1000)
+      : null;
+  const cooldownRemainingSeconds = nextAvailableAtDate
+    ? Math.max(0, Math.ceil((nextAvailableAtDate.getTime() - now.getTime()) / 1000))
+    : 0;
+  return {
+    bundleId,
+    name,
+    maxDownloads: row.maxDownloads,
+    downloadsUsed,
+    downloadsRemaining: remaining,
+    cooldownSeconds: row.cooldownSeconds,
+    lastDownloadAt: row.lastDownloadAt ? row.lastDownloadAt.toISOString() : null,
+    nextAvailableAt: nextAvailableAtDate ? nextAvailableAtDate.toISOString() : null,
+    cooldownRemainingSeconds,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,8 @@ import { registerOpenApiRoute } from "./routes/openapi.js";
 import { registerPortalRoutes } from "./routes/portal.js";
 import { registerPluginRoutes } from "./routes/admin/plugins.js";
 import { registerFileAdminRoutes } from "./routes/admin/files.js";
+import { registerBundleBuildAdminRoutes } from "./routes/admin/bundle-build.js";
+import { createBundleRebuildScheduler } from "./bundles/scheduler.js";
 import { registerAssignmentAdminRoutes } from "./routes/admin/assignments.js";
 
 export async function main() {
@@ -104,10 +106,18 @@ export async function main() {
   registerHealthRoutes(server, { queueName, storageName, checkDb, checkQueue, checkStorage });
   registerAdminAuthRoutes(server, config);
   registerRecipientAuthRoutes(server, config);
-  registerPortalRoutes(server, { storage: _storageService });
+  registerPortalRoutes(server, { storage: _storageService, scheduler: rebuilder });
   registerCliAuthRoutes(server, config);
   registerPluginRoutes(server);
-  registerFileAdminRoutes(server, { storage: _storageService });
+  // Initialize bundle rebuild scheduler and wire to file updates
+  const rebuilder = createBundleRebuildScheduler({ db: getDb(), storage: _storageService });
+  registerFileAdminRoutes(server, {
+    storage: _storageService,
+    onFilesChanged: async (fileIds) => {
+      await rebuilder.scheduleForFiles(fileIds);
+    },
+  });
+  registerBundleBuildAdminRoutes(server, { storage: _storageService, scheduler: rebuilder });
   registerAssignmentAdminRoutes(server);
   registerOpenApiRoute(server);
   await server.listen(config.PORT);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,14 +103,14 @@ export async function main() {
     return;
   };
 
+  // Initialize bundle rebuild scheduler before route registration
+  const rebuilder = createBundleRebuildScheduler({ db: getDb(), storage: _storageService });
   registerHealthRoutes(server, { queueName, storageName, checkDb, checkQueue, checkStorage });
   registerAdminAuthRoutes(server, config);
   registerRecipientAuthRoutes(server, config);
   registerPortalRoutes(server, { storage: _storageService, scheduler: rebuilder });
   registerCliAuthRoutes(server, config);
   registerPluginRoutes(server);
-  // Initialize bundle rebuild scheduler and wire to file updates
-  const rebuilder = createBundleRebuildScheduler({ db: getDb(), storage: _storageService });
   registerFileAdminRoutes(server, {
     storage: _storageService,
     onFilesChanged: async (fileIds) => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ import { registerOpenApiRoute } from "./routes/openapi.js";
 import { registerPortalRoutes } from "./routes/portal.js";
 import { registerPluginRoutes } from "./routes/admin/plugins.js";
 import { registerFileAdminRoutes } from "./routes/admin/files.js";
+import { registerAssignmentAdminRoutes } from "./routes/admin/assignments.js";
 
 export async function main() {
   const config = loadConfig();
@@ -107,6 +108,7 @@ export async function main() {
   registerCliAuthRoutes(server, config);
   registerPluginRoutes(server);
   registerFileAdminRoutes(server, { storage: _storageService });
+  registerAssignmentAdminRoutes(server);
   registerOpenApiRoute(server);
   await server.listen(config.PORT);
   // eslint-disable-next-line no-console

--- a/packages/core/src/routes/admin/assignments.test.ts
+++ b/packages/core/src/routes/admin/assignments.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { HttpHandler } from "../../http/http-server.js";
+
+// Mock DB client
+const db = {
+  bundleAssignment: {
+    findMany: vi.fn(async () => [] as any[]),
+  },
+  downloadEvent: {
+    count: vi.fn(async () => 0),
+  },
+};
+
+vi.mock("../../db/db.js", () => ({ getDb: () => db }));
+
+// Default: requireSession passes for admin permission middleware
+vi.mock("../../middleware/require-session.js", () => ({
+  requireSession: vi.fn(async () => ({ user: { id: "u1", role: "ADMIN" } })),
+}));
+
+function makeServer() {
+  const handlers = new Map<string, HttpHandler>();
+  const server = {
+    get: (p: string, h: HttpHandler) => handlers.set(`GET ${p}`, h),
+  } as any;
+  return { handlers, server };
+}
+
+describe("admin assignments routes", () => {
+  beforeEach(() => {
+    db.bundleAssignment.findMany.mockReset();
+    db.downloadEvent.count.mockReset();
+  });
+
+  it("GET /admin/bundles/:bundleId/assignments returns summaries", async () => {
+    const { handlers, server } = makeServer();
+    const { registerAssignmentAdminRoutes } = await import("./assignments.js");
+    registerAssignmentAdminRoutes(server);
+    const now = Date.now();
+    db.bundleAssignment.findMany.mockResolvedValueOnce([
+      {
+        id: "A1",
+        bundleId: "B1",
+        recipientId: "R1",
+        isEnabled: true,
+        maxDownloads: 3,
+        cooldownSeconds: 10,
+        lastDownloadAt: new Date(now - 15000),
+        bundle: { id: "B1", name: "Bundle 1" },
+        recipient: { id: "R1", email: "r@example.com", name: "Rec" },
+        updatedAt: new Date(now),
+      },
+    ] as any);
+    db.downloadEvent.count.mockResolvedValueOnce(2);
+    const h = handlers.get("GET /admin/bundles/:bundleId/assignments")!;
+    let status = 0;
+    let body: any = null;
+    await h({ params: { bundleId: "B1" } } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json(p: any) {
+        body = p;
+      },
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(200);
+    expect(Array.isArray(body?.items)).toBe(true);
+    expect(body.items[0].bundleId).toBe("B1");
+    expect(body.items[0].downloadsUsed).toBe(2);
+    expect(body.items[0].downloadsRemaining).toBe(1);
+  });
+
+  it("GET /admin/recipients/:recipientId/assignments returns summaries", async () => {
+    const { handlers, server } = makeServer();
+    const { registerAssignmentAdminRoutes } = await import("./assignments.js");
+    registerAssignmentAdminRoutes(server);
+    db.bundleAssignment.findMany.mockResolvedValueOnce([
+      {
+        id: "A2",
+        bundleId: "B2",
+        recipientId: "R2",
+        isEnabled: true,
+        maxDownloads: null,
+        cooldownSeconds: null,
+        lastDownloadAt: null,
+        bundle: { id: "B2", name: "Bundle 2" },
+        recipient: { id: "R2", email: "r2@example.com", name: null },
+        updatedAt: new Date(),
+      },
+    ] as any);
+    db.downloadEvent.count.mockResolvedValueOnce(0);
+    const h = handlers.get("GET /admin/recipients/:recipientId/assignments")!;
+    let status = 0;
+    let body: any = null;
+    await h({ params: { recipientId: "R2" } } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json(p: any) {
+        body = p;
+      },
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(200);
+    expect(body.items[0].recipientId).toBe("R2");
+    expect(body.items[0].downloadsRemaining).toBeNull();
+  });
+});

--- a/packages/core/src/routes/admin/assignments.ts
+++ b/packages/core/src/routes/admin/assignments.ts
@@ -1,0 +1,127 @@
+import type { HttpServer } from "../../http/http-server.js";
+import { getDb } from "../../db/db.js";
+import { requirePermission } from "../../middleware/require-permission.js";
+
+export function registerAssignmentAdminRoutes(server: HttpServer) {
+  const db = getDb();
+
+  // GET /admin/bundles/:bundleId/assignments — list assignment summaries for a bundle
+  server.get(
+    "/admin/bundles/:bundleId/assignments",
+    requirePermission("GET /admin/bundles")(async (req, res) => {
+      const params = (req.params as Record<string, string> | undefined) ?? {};
+      const bundleId = params.bundleId;
+      const now = new Date();
+      const qp = (req.query ?? {}) as Record<string, string>;
+      const limit = Math.max(1, Math.min(100, Number(qp["limit"]) || 50));
+
+      const rows = await db.bundleAssignment.findMany({
+        where: { bundleId },
+        take: limit,
+        orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
+        select: {
+          id: true,
+          bundleId: true,
+          recipientId: true,
+          isEnabled: true,
+          maxDownloads: true,
+          cooldownSeconds: true,
+          lastDownloadAt: true,
+          bundle: { select: { id: true, name: true } },
+          recipient: { select: { id: true, email: true, name: true } },
+          updatedAt: true,
+        },
+      });
+      const items = await Promise.all(
+        rows.map(async (a) => {
+          const used = await db.downloadEvent.count({ where: { bundleAssignmentId: a.id } });
+          const remaining = a.maxDownloads != null ? Math.max(0, a.maxDownloads - used) : null;
+          const nextAvailableAt =
+            a.cooldownSeconds != null && a.lastDownloadAt
+              ? new Date(a.lastDownloadAt.getTime() + a.cooldownSeconds * 1000)
+              : null;
+          const cooldownRemainingSeconds = nextAvailableAt
+            ? Math.max(0, Math.ceil((nextAvailableAt.getTime() - now.getTime()) / 1000))
+            : 0;
+          return {
+            assignmentId: a.id,
+            bundleId: a.bundle?.id ?? a.bundleId,
+            bundleName: a.bundle?.name ?? "",
+            recipientId: a.recipientId,
+            recipientEmail: a.recipient?.email ?? "",
+            recipientName: a.recipient?.name ?? null,
+            isEnabled: a.isEnabled,
+            maxDownloads: a.maxDownloads ?? null,
+            downloadsUsed: used,
+            downloadsRemaining: remaining,
+            cooldownSeconds: a.cooldownSeconds ?? null,
+            lastDownloadAt: a.lastDownloadAt ? a.lastDownloadAt.toISOString() : null,
+            nextAvailableAt: nextAvailableAt ? nextAvailableAt.toISOString() : null,
+            cooldownRemainingSeconds,
+          };
+        }),
+      );
+      res.status(200).json({ items });
+    }),
+  );
+
+  // GET /admin/recipients/:recipientId/assignments — list assignment summaries for a recipient
+  server.get(
+    "/admin/recipients/:recipientId/assignments",
+    requirePermission("GET /admin/recipients")(async (req, res) => {
+      const params = (req.params as Record<string, string> | undefined) ?? {};
+      const recipientId = params.recipientId;
+      const now = new Date();
+      const qp = (req.query ?? {}) as Record<string, string>;
+      const limit = Math.max(1, Math.min(100, Number(qp["limit"]) || 50));
+
+      const rows = await db.bundleAssignment.findMany({
+        where: { recipientId },
+        take: limit,
+        orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
+        select: {
+          id: true,
+          bundleId: true,
+          recipientId: true,
+          isEnabled: true,
+          maxDownloads: true,
+          cooldownSeconds: true,
+          lastDownloadAt: true,
+          bundle: { select: { id: true, name: true } },
+          recipient: { select: { id: true, email: true, name: true } },
+          updatedAt: true,
+        },
+      });
+      const items = await Promise.all(
+        rows.map(async (a) => {
+          const used = await db.downloadEvent.count({ where: { bundleAssignmentId: a.id } });
+          const remaining = a.maxDownloads != null ? Math.max(0, a.maxDownloads - used) : null;
+          const nextAvailableAt =
+            a.cooldownSeconds != null && a.lastDownloadAt
+              ? new Date(a.lastDownloadAt.getTime() + a.cooldownSeconds * 1000)
+              : null;
+          const cooldownRemainingSeconds = nextAvailableAt
+            ? Math.max(0, Math.ceil((nextAvailableAt.getTime() - now.getTime()) / 1000))
+            : 0;
+          return {
+            assignmentId: a.id,
+            bundleId: a.bundle?.id ?? a.bundleId,
+            bundleName: a.bundle?.name ?? "",
+            recipientId: a.recipientId,
+            recipientEmail: a.recipient?.email ?? "",
+            recipientName: a.recipient?.name ?? null,
+            isEnabled: a.isEnabled,
+            maxDownloads: a.maxDownloads ?? null,
+            downloadsUsed: used,
+            downloadsRemaining: remaining,
+            cooldownSeconds: a.cooldownSeconds ?? null,
+            lastDownloadAt: a.lastDownloadAt ? a.lastDownloadAt.toISOString() : null,
+            nextAvailableAt: nextAvailableAt ? nextAvailableAt.toISOString() : null,
+            cooldownRemainingSeconds,
+          };
+        }),
+      );
+      res.status(200).json({ items });
+    }),
+  );
+}

--- a/packages/core/src/routes/admin/bundle-build.test.ts
+++ b/packages/core/src/routes/admin/bundle-build.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { HttpHandler } from "../../http/http-server.js";
+
+// Mock DB and builder
+const db = {
+  bundle: {
+    findUnique: vi.fn(async () => null as any),
+    update: vi.fn(async () => ({}) as any),
+  },
+};
+
+vi.mock("../../db/db.js", () => ({ getDb: () => db }));
+
+const storage = {} as any;
+const scheduler = {
+  schedule: vi.fn(async () => void 0),
+  getStatus: vi.fn(() => ({ state: "idle" as const })),
+} as any;
+
+vi.mock("../../bundles/builder.js", () => ({
+  buildBundleArtifact: vi.fn(async () => ({
+    status: "built",
+    storageKey: "objects/sha256/00/00/zip",
+    checksum: "etag",
+    size: 123,
+    digest: "deadbeef",
+  })),
+}));
+
+function makeServer() {
+  const handlers = new Map<string, HttpHandler>();
+  const server = {
+    post: (p: string, h: HttpHandler) => handlers.set(`POST ${p}`, h),
+    get: (p: string, h: HttpHandler) => handlers.set(`GET ${p}`, h),
+  } as any;
+  return { handlers, server };
+}
+
+// Allow through permission middleware
+vi.mock("../../middleware/require-session.js", () => ({
+  requireSession: vi.fn(async () => ({ user: { id: "u1", role: "ADMIN" } })),
+}));
+
+describe("admin bundle build routes (unit)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    db.bundle.findUnique.mockReset();
+    db.bundle.update.mockReset();
+  });
+
+  it("POST /admin/bundles/:bundleId/build triggers build and returns result", async () => {
+    const { handlers, server } = makeServer();
+    const { registerBundleBuildAdminRoutes } = await import("./bundle-build.js");
+    registerBundleBuildAdminRoutes(server, { storage, scheduler });
+    db.bundle.findUnique.mockResolvedValueOnce({ id: "B1" });
+    const h = handlers.get("POST /admin/bundles/:bundleId/build")!;
+    let status = 0;
+    let body: any = null;
+    await h({ params: { bundleId: "B1" }, body: { force: true } } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json(p: any) {
+        body = p;
+      },
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(202);
+    expect(body?.status).toBe("queued");
+    expect(scheduler.schedule).toHaveBeenCalledWith("B1", { force: true });
+  });
+
+  it("GET /admin/bundles/:bundleId/build/status returns bundle pointers", async () => {
+    const { handlers, server } = makeServer();
+    const { registerBundleBuildAdminRoutes } = await import("./bundle-build.js");
+    scheduler.getStatus.mockReturnValueOnce({ state: "queued" });
+    registerBundleBuildAdminRoutes(server, { storage, scheduler });
+    db.bundle.findUnique.mockResolvedValueOnce({
+      id: "B1",
+      bundleDigest: "abcd",
+      storagePath: "objects/sha256/..",
+      checksum: "etag",
+      updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+    } as any);
+    const h = handlers.get("GET /admin/bundles/:bundleId/build/status")!;
+    let status = 0;
+    let body: any = null;
+    await h({ params: { bundleId: "B1" } } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json(p: any) {
+        body = p;
+      },
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(200);
+    expect(body?.bundleId).toBe("B1");
+    expect(body?.bundleDigest).toBe("abcd");
+    expect(body?.status).toBe("queued");
+  });
+});

--- a/packages/core/src/routes/admin/bundle-build.ts
+++ b/packages/core/src/routes/admin/bundle-build.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import type { HttpServer } from "../../http/http-server.js";
+import { getDb } from "../../db/db.js";
+import { requirePermission } from "../../middleware/require-permission.js";
+import type { StorageService } from "../../storage/service.js";
+import type { BundleRebuildScheduler } from "../../bundles/scheduler.js";
+
+export function registerBundleBuildAdminRoutes(
+  server: HttpServer,
+  deps: { storage: StorageService; scheduler: BundleRebuildScheduler },
+) {
+  const db = getDb();
+
+  // POST /admin/bundles/:bundleId/build — trigger a build immediately
+  server.post(
+    "/admin/bundles/:bundleId/build",
+    requirePermission("POST /admin/bundles/:bundleId/build")(async (req, res) => {
+      try {
+        const P = z.object({ bundleId: z.string().min(1) });
+        const B = z.object({ force: z.coerce.boolean().optional() }).optional();
+        const pp = P.safeParse((req.params ?? {}) as Record<string, unknown>);
+        const bb = B.safeParse((req.body ?? {}) as Record<string, unknown>);
+        if (!pp.success) {
+          res.status(400).json({ status: "error", code: "BAD_REQUEST", message: "Invalid params" });
+          return;
+        }
+        const bundle = await db.bundle.findUnique({ where: { id: pp.data.bundleId } });
+        if (!bundle) {
+          res.status(404).json({ status: "error", code: "NOT_FOUND", message: "Bundle not found" });
+          return;
+        }
+        const force = Boolean(bb.success ? bb.data?.force : false);
+        await deps.scheduler.schedule(pp.data.bundleId, { force });
+        res.status(202).json({ status: "queued" });
+      } catch (e) {
+        const err = e as Error & { status?: number };
+        res
+          .status(err.status ?? 500)
+          .json({ status: "error", code: "BUILD_FAILED", message: err.message });
+      }
+    }),
+  );
+
+  // GET /admin/bundles/:bundleId/build/status — return current digest/pointers
+  server.get(
+    "/admin/bundles/:bundleId/build/status",
+    requirePermission("GET /admin/bundles/:bundleId/build/status")(async (req, res) => {
+      try {
+        const P = z.object({ bundleId: z.string().min(1) });
+        const pp = P.safeParse((req.params ?? {}) as Record<string, unknown>);
+        if (!pp.success) {
+          res.status(400).json({ status: "error", code: "BAD_REQUEST", message: "Invalid params" });
+          return;
+        }
+        const b = await db.bundle.findUnique({
+          where: { id: pp.data.bundleId },
+          select: {
+            id: true,
+            bundleDigest: true,
+            storagePath: true,
+            checksum: true,
+            updatedAt: true,
+          },
+        });
+        if (!b) {
+          res.status(404).json({ status: "error", code: "NOT_FOUND", message: "Bundle not found" });
+          return;
+        }
+        const s = deps.scheduler.getStatus(pp.data.bundleId);
+        res.status(200).json({
+          status: s.state,
+          bundleId: b.id,
+          bundleDigest: b.bundleDigest,
+          storagePath: b.storagePath,
+          checksum: b.checksum,
+          updatedAt: b.updatedAt?.toISOString?.() ?? null,
+          ...(s.last ? { last: s.last } : {}),
+        });
+      } catch (e) {
+        const err = e as Error & { status?: number };
+        res
+          .status(err.status ?? 500)
+          .json({ status: "error", code: "STATUS_FAILED", message: err.message });
+      }
+    }),
+  );
+}

--- a/packages/core/src/routes/portal.test.ts
+++ b/packages/core/src/routes/portal.test.ts
@@ -342,11 +342,19 @@ describe("portal routes (unit)", () => {
       checksum: "dbsum",
       bundleDigest: "old",
     } as any);
-    // Second bundle fetch inside lazy check compares digest
-    db.bundle.findUnique.mockResolvedValueOnce({ bundleDigest: "old" } as any);
-    // Mock computeBundleDigest via DB: it calls bundle.findUnique under the hood, but
-    // our second findUnique is used above; to force mismatch, ensure compute returns different digest
-    // Here we instead let computeBundleDigest run and keep the mismatch by simulating different values
+    // computeBundleDigest will call db.bundle.findUnique with a select for bundleObjects; return one object
+    db.bundle.findUnique.mockResolvedValueOnce({
+      id: "B1",
+      bundleObjects: [
+        {
+          fileId: "F1",
+          path: "a.txt",
+          required: true,
+          sortOrder: 1,
+          file: { id: "F1", contentHash: "h1" },
+        },
+      ],
+    } as any);
     const h = handlers.get("GET /portal/bundles/:bundleId")!;
     const rc = resCapture();
     await h(

--- a/packages/core/src/routes/portal.ts
+++ b/packages/core/src/routes/portal.ts
@@ -2,9 +2,28 @@ import type { HttpServer } from "../http/http-server.js";
 import { getDb } from "../db/db.js";
 import { requireRecipient } from "../middleware/require-recipient.js";
 import type { StorageService } from "../storage/service.js";
+import type { Prisma } from "@latchflow/db";
 
 export function registerPortalRoutes(server: HttpServer, deps: { storage: StorageService }) {
   const db = getDb();
+
+  // Minimal DB surface used inside the transactional download path
+  type AssignmentRow = {
+    isEnabled?: boolean;
+    lastDownloadAt?: Date | null;
+    cooldownSeconds?: number | null;
+    maxDownloads?: number | null;
+  };
+  async function runInTx<T>(fn: (tx: Prisma.TransactionClient) => Promise<T>): Promise<T> {
+    const candidate = db as unknown as {
+      $transaction?: <R>(cb: (tx: unknown) => Promise<R>) => Promise<R>;
+    };
+    if (typeof candidate.$transaction === "function") {
+      return candidate.$transaction((tx: unknown) => fn(tx as Prisma.TransactionClient));
+    }
+    // Fallback for test mocks without $transaction
+    return fn(db as unknown as Prisma.TransactionClient);
+  }
 
   // GET /portal/me
   server.get("/portal/me", async (req, res) => {
@@ -21,7 +40,8 @@ export function registerPortalRoutes(server: HttpServer, deps: { storage: Storag
       });
       const bundles = assignments
         .map((a) => a.bundle)
-        .filter((b): b is { id: string; name: string } => Boolean(b));
+        .filter((b): b is { id: string; name: string } => Boolean(b))
+        .map((b) => ({ bundleId: b.id, name: b.name }));
       res.status(200).json({ recipient, bundles });
     } catch (e) {
       const err = e as Error & { status?: number };
@@ -37,16 +57,46 @@ export function registerPortalRoutes(server: HttpServer, deps: { storage: Storag
       const { session } = await requireRecipient(req, false);
       const qp = (req.query ?? {}) as Record<string, string>;
       const limit = Math.max(1, Math.min(100, Number(qp["limit"]) || 50));
+      const rawCursor = qp["cursor"];
+      let after: { updatedAt: string; id: string } | null = null;
+      if (rawCursor && typeof rawCursor === "string") {
+        try {
+          const decoded = Buffer.from(rawCursor, "base64").toString("utf8");
+          const obj = JSON.parse(decoded);
+          if (obj && typeof obj.updatedAt === "string" && typeof obj.id === "string") {
+            after = { updatedAt: obj.updatedAt, id: obj.id };
+          }
+        } catch {
+          // ignore bad cursor
+        }
+      }
+      const whereBase = {
+        recipientId: session.recipientId,
+        isEnabled: true,
+        recipient: { isEnabled: true },
+        bundle: { isEnabled: true },
+      } as const;
+      const where = after
+        ? {
+            AND: [
+              whereBase,
+              {
+                OR: [
+                  { updatedAt: { lt: new Date(after.updatedAt) } },
+                  { AND: [{ updatedAt: new Date(after.updatedAt) }, { id: { lt: after.id } }] },
+                ],
+              },
+            ],
+          }
+        : whereBase;
+      type FindManyArgs = NonNullable<Parameters<typeof db.bundleAssignment.findMany>[0]>;
       const assignments = await db.bundleAssignment.findMany({
-        where: {
-          recipientId: session.recipientId,
-          isEnabled: true,
-          recipient: { isEnabled: true },
-          bundle: { isEnabled: true },
-        },
+        where: where as FindManyArgs["where"],
         take: limit,
-        orderBy: { updatedAt: "desc" },
+        orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
         select: {
+          id: true,
+          updatedAt: true,
           bundle: {
             select: {
               id: true,
@@ -61,7 +111,17 @@ export function registerPortalRoutes(server: HttpServer, deps: { storage: Storag
         },
       });
       const items = assignments.map((a) => a.bundle).filter(Boolean);
-      res.status(200).json({ items });
+      const last = assignments[assignments.length - 1] as
+        | { updatedAt?: Date; id?: string }
+        | undefined;
+      const nextCursor =
+        last?.updatedAt && last?.id
+          ? Buffer.from(
+              JSON.stringify({ updatedAt: last.updatedAt.toISOString(), id: last.id }),
+              "utf8",
+            ).toString("base64")
+          : undefined;
+      res.status(200).json({ items, ...(nextCursor ? { nextCursor } : {}) });
     } catch (e) {
       const err = e as Error & { status?: number };
       res
@@ -95,79 +155,82 @@ export function registerPortalRoutes(server: HttpServer, deps: { storage: Storag
     try {
       const { assignment } = await requireRecipient(req, true);
       const now = new Date();
-      // Enforcement: verification
-      if (assignment.verificationType && !assignment.verificationMet) {
-        res
-          .status(403)
-          .json({
-            status: "error",
-            code: "VERIFICATION_REQUIRED",
-            message: "Verification required",
+      // Atomic enforcement + event insert (before fetching bundle)
+      try {
+        await runInTx(async (tx) => {
+          const fresh = await tx.bundleAssignment.findUnique({ where: { id: assignment.id } });
+          const current: AssignmentRow | null = fresh ?? {
+            isEnabled: true,
+            lastDownloadAt: assignment.lastDownloadAt ?? null,
+            cooldownSeconds: assignment.cooldownSeconds ?? null,
+            maxDownloads: assignment.maxDownloads ?? null,
+          };
+          if (!current || current.isEnabled === false) {
+            throw Object.assign(new Error("Not authorized"), { status: 403 });
+          }
+          const used = await tx.downloadEvent.count({
+            where: { bundleAssignmentId: assignment.id },
           });
+          if (current.maxDownloads != null && used >= current.maxDownloads) {
+            throw Object.assign(new Error("Download limit reached"), {
+              status: 403,
+              code: "MAX_DOWNLOADS_EXCEEDED",
+            });
+          }
+          if (
+            current.cooldownSeconds != null &&
+            current.lastDownloadAt &&
+            current.lastDownloadAt.getTime() + current.cooldownSeconds * 1000 > now.getTime()
+          ) {
+            throw Object.assign(new Error("Please wait before next download"), {
+              status: 429,
+              code: "COOLDOWN_ACTIVE",
+            });
+          }
+          await tx.downloadEvent.create({
+            data: {
+              bundleAssignmentId: assignment.id,
+              downloadedAt: now,
+              ip: req.ip ?? "",
+              userAgent: req.userAgent ?? "",
+            },
+          });
+          await tx.bundleAssignment.update({
+            where: { id: assignment.id },
+            data: { lastDownloadAt: now },
+          });
+        });
+      } catch (err) {
+        const ee = err as Error & { status?: number; code?: string };
+        const status = ee.status ?? 409;
+        const code = ee.code ?? (status === 429 ? "COOLDOWN_ACTIVE" : "MAX_DOWNLOADS_EXCEEDED");
+        res.status(status).json({ status: "error", code, message: ee.message });
         return;
       }
-      // Enforcement: maxDownloads
-      const used = await db.downloadEvent.count({ where: { bundleAssignmentId: assignment.id } });
-      if (assignment.maxDownloads != null && used >= assignment.maxDownloads) {
-        res
-          .status(403)
-          .json({
-            status: "error",
-            code: "MAX_DOWNLOADS_EXCEEDED",
-            message: "Download limit reached",
-          });
-        return;
-      }
-      // Enforcement: cooldown
-      if (
-        assignment.cooldownSeconds != null &&
-        assignment.lastDownloadAt &&
-        assignment.lastDownloadAt.getTime() + assignment.cooldownSeconds * 1000 > now.getTime()
-      ) {
-        res
-          .status(429)
-          .json({
-            status: "error",
-            code: "COOLDOWN_ACTIVE",
-            message: "Please wait before next download",
-          });
-        return;
-      }
-
-      // Fetch bundle
+      // Fetch bundle after enforcement
       const bundle = await db.bundle.findUnique({ where: { id: assignment.bundleId } });
       if (!bundle || (bundle as { isEnabled?: boolean }).isEnabled === false) {
         res.status(404).json({ status: "error", code: "NOT_FOUND", message: "Bundle not found" });
         return;
       }
       if (!bundle.storagePath) {
-        res
-          .status(409)
-          .json({
-            status: "error",
-            code: "NO_STORAGE_PATH",
-            message: "Bundle storage not available",
-          });
+        res.status(409).json({
+          status: "error",
+          code: "NO_STORAGE_PATH",
+          message: "Bundle storage not available",
+        });
         return;
       }
-
-      // Record download event & update assignment lastDownloadAt
-      await db.downloadEvent.create({
-        data: {
-          bundleAssignmentId: assignment.id,
-          downloadedAt: now,
-          ip: req.ip ?? "",
-          userAgent: req.userAgent ?? "",
-        },
-      });
-      await db.bundleAssignment.update({
-        where: { id: assignment.id },
-        data: { lastDownloadAt: now },
-      });
-
-      // Stream bundle archive
+      // Stream bundle archive (prefer storage-native ETag)
       const headers: Record<string, string> = { "Content-Type": "application/octet-stream" };
-      if (bundle.checksum) headers["ETag"] = bundle.checksum;
+      try {
+        const head = (await deps.storage.headFile(bundle.storagePath)) as { etag?: unknown };
+        if (typeof head?.etag === "string" || typeof head?.etag === "number") {
+          headers["ETag"] = String(head.etag);
+        }
+      } catch {
+        if (bundle.checksum) headers["ETag"] = bundle.checksum;
+      }
       const stream = await deps.storage.getFileStream(bundle.storagePath);
       res.sendStream(stream, headers);
     } catch (e) {

--- a/packages/core/src/storage/service.ts
+++ b/packages/core/src/storage/service.ts
@@ -75,7 +75,7 @@ export function createStorageService(deps: ServiceDeps) {
       recipientId: string;
       ttlSeconds?: number;
     }) => {
-      const url = `/portal/bundles/${args.bundleId}?rid=${args.recipientId}`;
+      const url = `/portal/bundles/${args.bundleId}`;
       const expiresAt = args.ttlSeconds
         ? new Date(Date.now() + args.ttlSeconds * 1000).toISOString()
         : undefined;

--- a/packages/core/src/types/zip-stream.d.ts
+++ b/packages/core/src/types/zip-stream.d.ts
@@ -1,0 +1,11 @@
+declare module "zip-stream" {
+  export default class ZipStream {
+    pipe(dst: NodeJS.WritableStream): void;
+    entry(
+      source: NodeJS.ReadableStream | Buffer,
+      options: { name: string; store?: boolean; date?: Date },
+      cb: (err: Error | null) => void,
+    ): void;
+    finish(cb: () => void): void;
+  }
+}

--- a/packages/core/tests/integration/admin-assignments.integration.test.ts
+++ b/packages/core/tests/integration/admin-assignments.integration.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { HttpHandler } from "../../src/http/http-server.js";
+
+// Prisma-like mock
+const db = {
+  bundleAssignment: {
+    findMany: vi.fn(async (): Promise<any[]> => []),
+  },
+  downloadEvent: {
+    count: vi.fn(async (): Promise<number> => 0),
+  },
+};
+
+vi.mock("../../src/db/db.js", () => ({ getDb: () => db }));
+
+// Allow through permission middleware
+vi.mock("../../src/middleware/require-session.js", () => ({
+  requireSession: vi.fn(async () => ({ user: { id: "u1", role: "ADMIN" } })),
+}));
+
+function makeServer() {
+  const handlers = new Map<string, HttpHandler>();
+  const server = {
+    get: (p: string, h: HttpHandler) => handlers.set(`GET ${p}`, h),
+  } as any;
+  return { handlers, server };
+}
+
+describe("admin assignments routes (integration)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    db.bundleAssignment.findMany.mockReset();
+    db.downloadEvent.count.mockReset();
+  });
+
+  it("GET /admin/bundles/:bundleId/assignments returns summaries and respects limit", async () => {
+    const { handlers, server } = makeServer();
+    const { registerAssignmentAdminRoutes } = await import("../../src/routes/admin/assignments.js");
+    registerAssignmentAdminRoutes(server);
+
+    // Seed two rows but expect only one due to limit=1
+    const now = new Date();
+    db.bundleAssignment.findMany.mockImplementationOnce(async (args: any) => {
+      // Verify limit is passed to DB
+      expect(args?.take).toBe(1);
+      return [
+        {
+          id: "A1",
+          bundleId: "B1",
+          recipientId: "R1",
+          isEnabled: true,
+          maxDownloads: 3,
+          cooldownSeconds: 10,
+          lastDownloadAt: new Date(now.getTime() - 60000), // cooldown elapsed
+          bundle: { id: "B1", name: "Bundle 1" },
+          recipient: { id: "R1", email: "r@example.com", name: "Rec" },
+          updatedAt: now,
+          _count: { downloadEvents: 2 },
+        },
+      ] as any[];
+    });
+
+    const h = handlers.get("GET /admin/bundles/:bundleId/assignments")!;
+    let status = 0;
+    let body: any = null;
+    await h({ params: { bundleId: "B1" }, query: { limit: "1" } } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json(p: any) {
+        body = p;
+      },
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(200);
+    expect(Array.isArray(body?.items)).toBe(true);
+    expect(body.items.length).toBe(1);
+    const it0 = body.items[0];
+    expect(it0.assignmentId).toBe("A1");
+    expect(it0.bundleId).toBe("B1");
+    expect(it0.bundleName).toBe("Bundle 1");
+    expect(it0.recipientId).toBe("R1");
+    expect(it0.recipientEmail).toBe("r@example.com");
+    expect(it0.downloadsUsed).toBe(2);
+    expect(it0.maxDownloads).toBe(3);
+    expect(it0.downloadsRemaining).toBe(1);
+    expect(it0.cooldownRemainingSeconds).toBe(0);
+  });
+
+  it("GET /admin/recipients/:recipientId/assignments falls back to downloadEvent.count when _count missing", async () => {
+    const { handlers, server } = makeServer();
+    const { registerAssignmentAdminRoutes } = await import("../../src/routes/admin/assignments.js");
+    registerAssignmentAdminRoutes(server);
+
+    db.bundleAssignment.findMany.mockResolvedValueOnce([
+      {
+        id: "A2",
+        bundleId: "B2",
+        recipientId: "R2",
+        isEnabled: true,
+        maxDownloads: null,
+        cooldownSeconds: null,
+        lastDownloadAt: null,
+        bundle: { id: "B2", name: "Bundle 2" },
+        recipient: { id: "R2", email: "r2@example.com", name: null },
+        updatedAt: new Date(),
+      },
+    ] as any);
+    db.downloadEvent.count.mockResolvedValueOnce(1);
+
+    const h = handlers.get("GET /admin/recipients/:recipientId/assignments")!;
+    let status = 0;
+    let body: any = null;
+    await h({ params: { recipientId: "R2" }, query: { limit: "10" } } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json(p: any) {
+        body = p;
+      },
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(200);
+    const it0 = body.items[0];
+    expect(it0.recipientId).toBe("R2");
+    expect(it0.downloadsUsed).toBe(1);
+    expect(it0.maxDownloads).toBeNull();
+    expect(it0.downloadsRemaining).toBeNull();
+  });
+});

--- a/packages/core/tests/integration/bundle-build.integration.test.ts
+++ b/packages/core/tests/integration/bundle-build.integration.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { HttpHandler } from "../../src/http/http-server.js";
+import { Readable } from "node:stream";
+import { createBundleRebuildScheduler } from "../../src/bundles/scheduler.js";
+
+// Mock zip-stream to avoid real zipping in integration test
+vi.mock("zip-stream", () => {
+  class FakeZip {
+    private chunks: Buffer[] = [];
+    pipe(dst: any) {
+      this._dst = dst;
+    }
+    entry(src: any, _opts: any, cb: (err: Error | null) => void) {
+      const collect = async () => {
+        if (Buffer.isBuffer(src)) this.chunks.push(Buffer.from(src));
+        else
+          await new Promise<void>((resolve) => {
+            src.on("data", (b: Buffer) => this.chunks.push(Buffer.from(b)));
+            src.on("end", resolve);
+          });
+        cb(null);
+      };
+      collect();
+    }
+    finish(cb: () => void) {
+      const buf = Buffer.concat(this.chunks);
+      if (this._dst && typeof this._dst.write === "function") this._dst.write(buf);
+      if (this._dst && typeof this._dst.end === "function") this._dst.end();
+      cb();
+    }
+  }
+  return { default: FakeZip } as any;
+});
+
+const db = {
+  bundle: {
+    findUnique: vi.fn(async (): Promise<any> => null),
+    update: vi.fn(async (args: any): Promise<any> => ({ ...args?.data })),
+  },
+  bundleObject: {
+    findMany: vi.fn(async (): Promise<any[]> => []),
+  },
+};
+vi.mock("../../src/db/db.js", () => ({ getDb: () => db }));
+
+function makeServer() {
+  const handlers = new Map<string, HttpHandler>();
+  const storage = {
+    getFileStream: vi.fn(async (key: string) => Readable.from(Buffer.from(`data:${key}`))),
+    putFile: vi.fn(async ({ body }: { body: Buffer }) => ({
+      storageKey: "objects/sha256/zz/zz/zip",
+      size: body.length,
+      sha256: "ziphash",
+      storageEtag: "zip-etag",
+    })),
+  } as any;
+  const server = {
+    post: (p: string, h: HttpHandler) => handlers.set(`POST ${p}`, h),
+    get: (p: string, h: HttpHandler) => handlers.set(`GET ${p}`, h),
+  } as any;
+  return { handlers, storage, server };
+}
+
+// Pass permission middleware
+vi.mock("../../src/middleware/require-session.js", () => ({
+  requireSession: vi.fn(async () => ({ user: { id: "u1", role: "ADMIN" } })),
+}));
+
+describe("bundle build (integration)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    for (const model of Object.values(db) as any[]) {
+      for (const fn of Object.values(model) as any[]) {
+        if (typeof fn?.mockReset === "function") fn.mockReset();
+      }
+    }
+  });
+
+  it("builds and updates bundle pointers", async () => {
+    const { handlers, server, storage } = makeServer();
+    const { registerBundleBuildAdminRoutes } = await import(
+      "../../src/routes/admin/bundle-build.js"
+    );
+    const scheduler = createBundleRebuildScheduler({ db: db as any, storage, debounceMs: 0 });
+    registerBundleBuildAdminRoutes(server, { storage, scheduler });
+    // First call from route parameter validation; second from digest computation
+    db.bundle.findUnique.mockResolvedValueOnce({ id: "B1", bundleDigest: "prev" });
+    db.bundle.findUnique.mockResolvedValueOnce({
+      id: "B1",
+      bundleObjects: [
+        {
+          fileId: "F1",
+          path: "a.txt",
+          required: true,
+          sortOrder: 1,
+          file: { id: "F1", contentHash: "h1" },
+        },
+        {
+          fileId: "F2",
+          path: null,
+          required: false,
+          sortOrder: 2,
+          file: { id: "F2", contentHash: "h2" },
+        },
+      ],
+    } as any);
+    db.bundleObject.findMany.mockResolvedValueOnce([
+      {
+        fileId: "F1",
+        path: "a.txt",
+        sortOrder: 1,
+        file: { id: "F1", key: "k1", storageKey: "s1", contentHash: "h1" },
+      },
+      {
+        fileId: "F2",
+        path: null,
+        sortOrder: 2,
+        file: { id: "F2", key: "k2", storageKey: "s2", contentHash: "h2" },
+      },
+    ]);
+    const h = handlers.get("POST /admin/bundles/:bundleId/build")!;
+    let status = 0;
+    let body: any = null;
+    await h({ params: { bundleId: "B1" }, body: {} } as any, {
+      status(c: number) {
+        status = c;
+        return this as any;
+      },
+      json(p: any) {
+        body = p;
+      },
+      header() {
+        return this as any;
+      },
+      redirect() {},
+      sendStream() {},
+      sendBuffer() {},
+    });
+    expect(status).toBe(202);
+    expect(body?.status).toBe("queued");
+    // allow scheduled task to run; poll a few times to reduce flake
+    for (let i = 0; i < 50 && db.bundle.update.mock.calls.length === 0; i++) {
+      // short sleep
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    // Ensure bundle update called with new pointers
+    const upd = db.bundle.update.mock.calls[0]?.[0]?.data;
+    expect(upd?.storagePath).toBe("objects/sha256/zz/zz/zip");
+    expect(upd?.checksum).toBe("zip-etag");
+    expect(typeof upd?.bundleDigest).toBe("string");
+  });
+});

--- a/packages/db/prisma/migrations/20250913224521_bundle_and_download_indices/migration.sql
+++ b/packages/db/prisma/migrations/20250913224521_bundle_and_download_indices/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "BundleAssignment_updatedAt_idx" ON "public"."BundleAssignment"("updatedAt");
+
+-- CreateIndex
+CREATE INDEX "DownloadEvent_bundleAssignmentId_idx" ON "public"."DownloadEvent"("bundleAssignmentId");

--- a/packages/db/prisma/migrations/20250914170222_add_bundle_digest/migration.sql
+++ b/packages/db/prisma/migrations/20250914170222_add_bundle_digest/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "public"."Bundle" ADD COLUMN     "bundleDigest" TEXT NOT NULL DEFAULT '';
+
+-- CreateIndex
+CREATE INDEX "Bundle_bundleDigest_idx" ON "public"."Bundle"("bundleDigest");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -193,6 +193,8 @@ model Bundle {
   name          String
   storagePath   String
   checksum      String
+  /// Digest of ordered bundle composition to skip unnecessary rebuilds
+  bundleDigest  String             @default("")
   description   String?
   isEnabled     Boolean            @default(true)
   bundleObjects BundleObject[]
@@ -204,6 +206,8 @@ model Bundle {
 
   creator User  @relation("createdBundles", fields: [createdBy], references: [id])
   updater User? @relation("updatedBundles", fields: [updatedBy], references: [id])
+
+  @@index([bundleDigest])
 }
 
 model BundleObject {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -252,6 +252,7 @@ model BundleAssignment {
 
   @@unique([bundleId, recipientId])
   @@index([bundleId, recipientId, isEnabled])
+  @@index([updatedAt])
 }
 
 model DownloadEvent {
@@ -265,6 +266,8 @@ model DownloadEvent {
   ip                 String
   file               File?            @relation(fields: [fileId], references: [id])
   fileId             String?
+
+  @@index([bundleAssignmentId])
 }
 
 ///////////////////////////


### PR DESCRIPTION
## **Summary**

- Move recipient authentication from bundle-scoped to account-scoped so a recipient can log in once to the portal and see all bundles they can access.
- Add enable/disable controls on recipients and bundle relationships to allow revocation without deleting data.
- Expose portal endpoints to fetch recipient identity, list accessible bundles, browse files, and download bundles while enforcing limits and throttles.
- Verification is performed at login only (no additional per-bundle verification required after session is established).
- Keep compliance with architectural rules: database access only via `@latchflow/db`, event logging for downloads, and no hardcoded plugin types.
- Keep zipped bundle files in storage and prefer storage-native ETags on downloads.

## **Scope**

- In scope
  - Recipient-level session model (cookie-based) independent of any bundle.
  - OTP-based login (recipient-level) with optional future magic-link support.
  - New/updated portal API routes: `GET /portal/me`, `GET /portal/bundles`, `GET /portal/bundles/{bundleId}/objects`, `GET /portal/bundles/{bundleId}`.
  - Prisma schema updates: `isEnabled` on `Recipient`, `BundleAssignment`, `Bundle`, and `BundleObject` (default true), plus indexes.
  - Unique index on `BundleAssignment(bundleId, recipientId)`.
  - Refactor OTP/session tables to recipient-scoped only (no `bundleId` columns).
  - Enforcement of per-assignment limits (`maxDownloads`, `cooldownSeconds`) at download time; no additional per-bundle verification step after login.
  - Update OpenAPI and core middleware for recipient auth.
  - Admin UI changes for toggling enable/disable flags where relevant.
  - Portal download uses storage-native ETag for responses; zipped bundle files are stored and streamed from storage.
  - Automatic bundle artifact rebuilds: on composition/content changes, enqueue a background job to rebuild the bundle archive and update `Bundle.storagePath` atomically once complete.
  - Expose assignment status summaries for UX:
    - Recipient portal: `GET /portal/assignments` returns per-assignment status (downloads used/remaining, cooldown timing).
    - Admin: `GET /bundles/{bundleId}/assignments` and `GET /recipients/{recipientId}/assignments` return the same summary for management views.

- Out of scope (for this story)
  - Recipient self-service profile management (name/email edits).
  - Theming/branding of the portal UI.
  - Email/SMS delivery providers beyond existing dev/local setup (MailHog).
  - Public link publishing (remains via `release_bundle` action only).

## **To-Do**

- Data model (Prisma)
  - [x] Ensure `isEnabled Boolean @default(true)` on `Recipient` with `@@index([isEnabled])`.
  - [x] Ensure `isEnabled Boolean @default(true)` on `BundleAssignment` with `@@index([bundleId, recipientId, isEnabled])`.
  - [x] Add index on `BundleAssignment(updatedAt)` to support portal pagination ordering.
  - [x] Ensure `isEnabled Boolean @default(true)` on `Bundle` and `BundleObject` (index `BundleObject(bundleId, isEnabled, sortOrder)`).
  - [x] Add/ensure unique index `@@unique([bundleId, recipientId])` on `BundleAssignment`.
  - [x] Confirm `RecipientSession` and `RecipientOtp` are recipient-scoped (no `bundleId`) and add per-recipient indexes.
  - [x] Add index on `DownloadEvent(bundleAssignmentId)` to speed up `downloadsUsed` counts.
  - [x] Add `bundleDigest String @default("")` on `Bundle` to store composition digest (ordered contents signature); add `@@index([bundleDigest])`.

- Core service (routes + middleware)
  - [x] Confirm `requireRecipient` optional bundle scope (already implemented); default is account-scoped (no bundle enforcement).
  - [x] `/auth/recipient/start` + `/auth/recipient/verify` accept `{ recipientId }` or `{ email }`; no `bundleId`.
  - [x] `/portal/auth/otp/resend` accepts `{ recipientId }` or `{ email }`.
  - [x] `GET /portal/me` returns `{ recipient, bundles[] }` where `bundles[]` items conform to spec (`{ bundleId, name }`).
  - [x] `GET /portal/bundles` implements cursor pagination per spec (`items`, optional `nextCursor`).
  - [x] Cursor token encodes `{ updatedAt, id }` of last item (base64 JSON); ordering is `updatedAt desc, id desc`.
  - [x] `GET /portal/bundles/{bundleId}/objects` (bundleScoped) honors `BundleObject.isEnabled`.
  - [x] `GET /portal/bundles/{bundleId}` (bundleScoped) enforces `maxDownloads` and `cooldownSeconds`; no additional verification after login.
  - [x] Use storage-native ETag for downloads (HEAD storage object and set `ETag`), streaming zipped bundle from storage.
  - [x] Ensure every download creates a `DownloadEvent` (bundle-level event; `fileId` null for archive, or per-file when streaming individual files if applicable).
  - [x] Make limit/cooldown enforcement atomic (transactionally count+insert+update).
  - [x] Implement `GET /portal/assignments` returning items: `{ bundleId, name, maxDownloads, downloadsUsed, downloadsRemaining, cooldownSeconds, lastDownloadAt, nextAvailableAt, cooldownRemainingSeconds }`.
  - [x] Implement admin endpoints `GET /bundles/{bundleId}/assignments` and `GET /recipients/{recipientId}/assignments` with the same summary shape; support pagination.
  - [x] Use Prisma `_count` of `downloadEvents` to compute `downloadsUsed` efficiently; compute remaining/cooldown fields server-side.
  - [x] Auto-rebuild pipeline:
    - [x] `computeBundleDigest(bundleId)` util: stable sha256 over ordered `{ fileId, file.contentHash, path, required, sortOrder }`.
    - [x] `buildBundleArtifact(bundleId)` job: streams files into a zip (deterministic order), `putFile` to storage, updates `Bundle.storagePath` and `Bundle.checksum`; sets `bundleDigest`.
    - [x] Queue and coalesce per-bundle builds; ensure one build at a time.
    - [x] Debounce rebuild scheduling (e.g., 2–5s window) to collapse bursts.
    - [ ] Schedule rebuild on:
      - [ ] BundleObject CRUD/reorder
      - [x] File content change (affects any referencing bundles)
      - [ ] Relevant bundle metadata changes
    - [x] Keep serving the previous artifact during rebuild; update pointer atomically when done.
  - [x] Add a shared mapper util to build `AssignmentSummary` DTOs from Prisma results (and a local TS type to mirror the OpenAPI schema).

- OpenAPI
  - [x] Update `packages/core/openapi` for changed recipient auth and portal routes (no per-bundle verification).
  - [x] Validate spec conformance for response shapes and pagination.
  - [x] Add schemas for `AssignmentSummary` and paths for `GET /portal/assignments`, `GET /admin/bundles/{bundleId}/assignments`, `GET /admin/recipients/{recipientId}/assignments`.
  - [x] Add admin endpoints for rebuild workflow: `POST /admin/bundles/{bundleId}/build` to trigger rebuild and `GET /admin/bundles/{bundleId}/build/status`.

- Tests
  - [x] Unit: `require-recipient` middleware for non-bundle and bundle-scoped flows.
  - [x] Unit: recipient auth routes (start/verify/resend) with rate limits and invalid cases.
  - [x] Integration: `GET /portal/me` and `GET /portal/bundles` filters (flags, disabled assignment, disabled bundle/object) + pagination.
  - [x] Integration: download enforcement (`maxDownloads`, `cooldownSeconds`) with transaction-based guard.
  - [x] Integration:
    - [x] `GET /portal/assignments` returns correct status fields
    - [x] Admin assignments endpoints paginate and compute counts correctly
  - [x] Unit: `computeBundleDigest` produces stable hashes.
  - [x] Unit: `buildBundleArtifact` writes deterministic archives and updates bundle fields.
  - [x] Integration: Rebuild scheduling triggers on BundleObject changes and File content changes (mock), job updates `storagePath`/`checksum`.
    - [x] File content changes
    - [ ] ~~BundleObject CRUD/reorder~~
  - [ ] ~~E2E (optional): Build a small bundle, verify download streams the new artifact after a change; old artifact is served until build completes.~~
  - [x] Ensure all tests run under `pnpm -r test` with no real network calls.

- Migration & rollout
  - [x] Perform clean schema changes (no compatibility flag needed at this stage).

- Documentation
  - [x] Update README and docs/architecture.md for recipient account-scoped portal model, enable/disable semantics, rate-limits, assignment status endpoints, and auto-rebuild semantics (digest, debounce, manual build endpoint).

## **DoD**

- [x] Recipients can log in once and fetch `GET /portal/me` showing their identity and at least one bundle when assigned/enabled.
 - [x] `GET /portal/bundles` returns only bundles where Recipient, Bundle, and BundleAssignment are all `isEnabled`, and supports cursor pagination.
 - [x] `GET /portal/assignments` returns per-assignment status (downloads used/remaining and cooldown timing) for the logged-in recipient.
 - [x] Admin assignments endpoints provide the same summary with pagination.
- [x] Download honors `maxDownloads` and `cooldownSeconds` atomically; attempts beyond limits return 429/403 with clear error.
- [x] Each download creates a `DownloadEvent` row with correct association to the `BundleAssignment` and request metadata.
- [x] New `isEnabled` fields exist on `Recipient`, `BundleAssignment`, `Bundle`, and `BundleObject` with indexes; admin UI can toggle them.
- [x] Recipient-level OTP flow works end-to-end; no per-bundle verification required after login.
- [x] OpenAPI is up to date; CI lints and tests pass via `pnpm -r test`.
- [x] No direct DB access from admin/portal apps; all access via core service.
 - [ ] ~~Bundle auto-rebuilds on composition/content change; pointer update is atomic; unnecessary rebuilds are skipped via bundleDigest.~~
