### PR TITLE
Trigger endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,15 @@ pnpm -r test
 - Verify bundle recipients before release (OTP/passphrase).
 - Enforce per-recipient download limits and rate throttles.
 
+### Admin Triggers
+- API paths live under `/triggers` (route code in `packages/core/src/routes/admin/triggers.ts`).
+- AuthZ is enforced via policy entries on resource `trigger_def`:
+  - Read: `GET /triggers`, `GET /triggers/:id` (v1 allows executor reads), scopes: `triggers:read`.
+  - Write: `POST /triggers`, `POST|PATCH /triggers/:id`, `DELETE /triggers/:id`, `POST /triggers/:id/test-fire`, scopes: `triggers:write`.
+- Capability validation is DB-backed: check `PluginCapability` (`kind = TRIGGER`, `isEnabled = true`). Do not depend on the in-memory runtime registry inside routes.
+- Delete semantics: return 409 when a trigger is referenced by pipelines or has events; prefer disabling (`isEnabled=false`).
+- Auditing: on create/update, append ChangeLog entries for `TRIGGER_DEFINITION` (canonical serializer redacts secrets).
+
 ---
 
 ## Coding Standards

--- a/packages/core/openapi/components/schemas/TriggerDefinition.yaml
+++ b/packages/core/openapi/components/schemas/TriggerDefinition.yaml
@@ -7,4 +7,4 @@ properties:
   isEnabled: { type: boolean }
   createdAt: { type: string, format: date-time }
   updatedAt: { type: string, format: date-time }
-required: [id, name, capabilityId, config, ownerId]
+required: [id, name, capabilityId, config, isEnabled, createdAt, updatedAt]

--- a/packages/core/openapi/openapi.yaml
+++ b/packages/core/openapi/openapi.yaml
@@ -184,10 +184,9 @@ paths:
     $ref: ./paths/triggers.yaml#/triggers_collection
   /triggers/{id}:
     $ref: ./paths/triggers.yaml#/triggers_item
-  /triggers/{id}/versions:
-    $ref: ./paths/triggers.yaml#/trigger_versions_collection
-  /triggers/{id}/versions/{version}:
-    $ref: ./paths/triggers.yaml#/trigger_versions_item
+  # Versioned trigger endpoints removed (use ChangeLog endpoints in the future)
+  /triggers/{id}/test-fire:
+    $ref: ./paths/triggers.yaml#/test_fire
   /actions:
     $ref: ./paths/actions.yaml#/actions_collection
   /actions/{id}:

--- a/packages/core/openapi/paths/triggers.yaml
+++ b/packages/core/openapi/paths/triggers.yaml
@@ -9,6 +9,22 @@ triggers_collection:
     parameters:
       - $ref: ../components/parameters/Limit.yaml
       - $ref: ../components/parameters/Cursor.yaml
+      - in: query
+        name: q
+        schema: { type: string }
+        description: Case-insensitive name search
+      - in: query
+        name: pluginId
+        schema: { type: string, format: uuid }
+      - in: query
+        name: capabilityKey
+        schema: { type: string }
+      - in: query
+        name: enabled
+        schema: { type: boolean }
+      - in: query
+        name: updatedSince
+        schema: { type: string, format: date-time }
     responses:
       '200':
         description: Triggers
@@ -53,6 +69,56 @@ triggers_collection:
       '400': { $ref: ../components/responses/ValidationError.yaml }
 
 triggers_item:
+  post:
+    summary: Update trigger definition (alias)
+    description: Some deployments may use POST for updates; semantics match PATCH.
+    operationId: updateTriggerPost
+    tags: [Triggers]
+    security:
+      - bearer: []
+      - cookieAdmin: []
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema: { type: string, format: uuid }
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name: { type: string }
+              isEnabled: { type: boolean }
+              config: { type: object }
+    responses:
+      '204': { description: Updated }
+      '401': { $ref: ../components/responses/Unauthorized.yaml }
+      '403': { $ref: ../components/responses/Forbidden.yaml }
+      '400': { $ref: ../components/responses/ValidationError.yaml }
+      '404': { $ref: ../components/responses/NotFound.yaml }
+  get:
+    summary: Get trigger definition
+    operationId: getTrigger
+    tags: [Triggers]
+    security:
+      - bearer: []
+      - cookieAdmin: []
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema: { type: string, format: uuid }
+    responses:
+      '200':
+        description: Trigger
+        content:
+          application/json:
+            schema: { $ref: ../components/schemas/TriggerDefinition.yaml }
+      '404': { $ref: ../components/responses/NotFound.yaml }
+      '401': { $ref: ../components/responses/Unauthorized.yaml }
+      '403': { $ref: ../components/responses/Forbidden.yaml }
   patch:
     summary: Update trigger definition
     operationId: updateTrigger
@@ -73,18 +139,17 @@ triggers_item:
             type: object
             properties:
               name: { type: string }
+              isEnabled: { type: boolean }
               config: { type: object }
     responses:
       '204': { description: Updated }
       '401': { $ref: ../components/responses/Unauthorized.yaml }
       '403': { $ref: ../components/responses/Forbidden.yaml }
       '400': { $ref: ../components/responses/ValidationError.yaml }
-
-# TriggerDefinition versions (history)
-trigger_versions_collection:
-  get:
-    summary: List trigger definition versions
-    operationId: listTriggerVersions
+      '404': { $ref: ../components/responses/NotFound.yaml }
+  delete:
+    summary: Delete trigger definition
+    operationId: deleteTrigger
     tags: [Triggers]
     security:
       - bearer: []
@@ -94,28 +159,16 @@ trigger_versions_collection:
         name: id
         required: true
         schema: { type: string, format: uuid }
-      - $ref: ../components/parameters/Limit.yaml
-      - $ref: ../components/parameters/Cursor.yaml
     responses:
-      '200':
-        description: Versions
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                items:
-                  type: array
-                  items: { $ref: ../components/schemas/ChangeLogVersion.yaml }
-                nextCursor: { type: string }
-              required: [items]
+      '204': { description: Deleted }
+      '404': { $ref: ../components/responses/NotFound.yaml }
+      '409': { $ref: ../components/responses/Conflict.yaml }
       '401': { $ref: ../components/responses/Unauthorized.yaml }
       '403': { $ref: ../components/responses/Forbidden.yaml }
-
-trigger_versions_item:
-  get:
-    summary: Get trigger definition version
-    operationId: getTriggerVersion
+test_fire:
+  post:
+    summary: Enqueue actions for a trigger definition
+    operationId: testFireTrigger
     tags: [Triggers]
     security:
       - bearer: []
@@ -125,15 +178,17 @@ trigger_versions_item:
         name: id
         required: true
         schema: { type: string, format: uuid }
-      - in: path
-        name: version
-        required: true
-        schema: { type: integer, minimum: 1 }
+    requestBody:
+      required: false
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              context: { type: object, additionalProperties: true }
     responses:
-      '200':
-        description: Materialized trigger definition at version
-        content:
-          application/json:
-            schema: { $ref: ../components/schemas/ChangeLogMaterialized.yaml }
+      '202': { description: Enqueued }
       '404': { $ref: ../components/responses/NotFound.yaml }
       '401': { $ref: ../components/responses/Unauthorized.yaml }
+      '403': { $ref: ../components/responses/Forbidden.yaml }
+      '503': { description: Trigger runner unavailable }

--- a/packages/core/src/authz/policy.ts
+++ b/packages/core/src/authz/policy.ts
@@ -5,6 +5,13 @@ import type { PolicyEntry } from "./types.js";
 export type RouteSignature = `${"GET" | "POST" | "PUT" | "PATCH" | "DELETE"} ${string}`;
 
 export const POLICY: Record<RouteSignature, PolicyEntry> = {
+  // Triggers (API paths; route code lives under admin)
+  "GET /triggers": { action: "read", resource: "trigger_def", v1AllowExecutor: true },
+  "POST /triggers": { action: "create", resource: "trigger_def" },
+  "GET /triggers/:id": { action: "read", resource: "trigger_def", v1AllowExecutor: true },
+  "PATCH /triggers/:id": { action: "update", resource: "trigger_def" },
+  "DELETE /triggers/:id": { action: "delete", resource: "trigger_def" },
+  "POST /triggers/:id/test-fire": { action: "update", resource: "trigger_def" },
   // Admin plugin management
   "GET /plugins": { action: "read", resource: "plugin", v1AllowExecutor: true },
   "POST /plugins/install": { action: "manage", resource: "plugin" },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ import { createStorageService } from "./storage/service.js";
 import { registerOpenApiRoute } from "./routes/openapi.js";
 import { registerPortalRoutes } from "./routes/portal.js";
 import { registerPluginRoutes } from "./routes/admin/plugins.js";
+import { registerTriggerAdminRoutes } from "./routes/admin/triggers.js";
 import { registerFileAdminRoutes } from "./routes/admin/files.js";
 import { registerBundleBuildAdminRoutes } from "./routes/admin/bundle-build.js";
 import { createBundleRebuildScheduler } from "./bundles/scheduler.js";
@@ -72,7 +73,7 @@ export async function main() {
     },
   });
 
-  await startTriggerRunner({
+  const triggerRunner = await startTriggerRunner({
     onFire: async (msg) => queue.enqueueAction(msg),
   });
 
@@ -112,6 +113,7 @@ export async function main() {
   registerPortalRoutes(server, { storage: _storageService, scheduler: rebuilder });
   registerCliAuthRoutes(server, config);
   registerPluginRoutes(server);
+  registerTriggerAdminRoutes(server, { fireTriggerOnce: triggerRunner.fireTriggerOnce, config });
   registerFileAdminRoutes(server, {
     storage: _storageService,
     onFilesChanged: async (fileIds) => {

--- a/packages/core/src/routes/admin/triggers.test.ts
+++ b/packages/core/src/routes/admin/triggers.test.ts
@@ -180,7 +180,6 @@ describe("triggers routes", () => {
     expect(rc.status).toBe(204);
     const args = (db.triggerDefinition.update as any).mock.calls[0]?.[0]?.data;
     expect(args).toHaveProperty("isEnabled", false);
-    expect(args).toHaveProperty("updatedBy");
   });
 
   it("DELETE /triggers/:id returns 409 when in use", async () => {

--- a/packages/core/src/routes/admin/triggers.test.ts
+++ b/packages/core/src/routes/admin/triggers.test.ts
@@ -1,13 +1,112 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { registerTriggerAdminRoutes } from "../../routes/admin/triggers.js";
 import type { HttpHandler } from "../../http/http-server.js";
 
-describe("admin triggers route", () => {
-  it("returns 501 not implemented", async () => {
-    const handlers = new Map<string, HttpHandler>();
-    const server = { get: (p: string, h: HttpHandler) => handlers.set(`GET ${p}`, h) } as any;
-    registerTriggerAdminRoutes(server);
-    const h = handlers.get("GET /admin/triggers")!;
+const db = {
+  triggerDefinition: {
+    findMany: vi.fn(async () => []),
+    findUnique: vi.fn(async () => null),
+    create: vi.fn(async (..._args: any[]) => ({})),
+    update: vi.fn(async (..._args: any[]) => ({})),
+    delete: vi.fn(async (..._args: any[]) => ({})),
+  },
+  pluginCapability: {
+    findUnique: vi.fn(async () => null),
+  },
+  triggerEvent: { count: vi.fn(async () => 0) },
+  pipelineTrigger: { count: vi.fn(async () => 0) },
+  apiToken: { findUnique: vi.fn(async () => null), update: vi.fn(async () => ({})) },
+  user: { findUnique: vi.fn(async () => null) },
+};
+
+vi.mock("../../db/db.js", () => ({ getDb: () => db }));
+
+// Default: requireSession passes
+vi.mock("../../middleware/require-session.js", () => ({
+  requireSession: vi.fn(async () => ({ user: { id: "u1", role: "ADMIN" } })),
+}));
+
+// Stub ChangeLog appends
+vi.mock("../../history/changelog.js", () => ({
+  appendChangeLog: vi.fn(async () => ({ id: "cl1", version: 1 })),
+}));
+
+async function makeServer() {
+  const handlers = new Map<string, HttpHandler>();
+  const server = {
+    get: (p: string, h: HttpHandler) => handlers.set(`GET ${p}`, h),
+    post: (p: string, h: HttpHandler) => handlers.set(`POST ${p}`, h),
+    patch: (p: string, h: HttpHandler) => handlers.set(`PATCH ${p}`, h),
+    delete: (p: string, h: HttpHandler) => handlers.set(`DELETE ${p}`, h),
+  } as any;
+  registerTriggerAdminRoutes(server, {
+    fireTriggerOnce: async () => {},
+    config: {
+      HISTORY_SNAPSHOT_INTERVAL: 20,
+      HISTORY_MAX_CHAIN_DEPTH: 200,
+      SYSTEM_USER_ID: "sys",
+    } as any,
+  });
+  return { handlers };
+}
+
+function resCapture() {
+  let status = 0;
+  let body: any = null;
+  const headers: Record<string, string | string[]> = {};
+  const res = {
+    status(c: number) {
+      status = c;
+      return this as any;
+    },
+    json(p: any) {
+      body = p;
+    },
+    header(name: string, value: any) {
+      headers[name] = value;
+      return this as any;
+    },
+    redirect() {},
+    sendStream() {},
+    sendBuffer() {},
+  } as any;
+  return {
+    res,
+    get status() {
+      return status;
+    },
+    get body() {
+      return body;
+    },
+    get headers() {
+      return headers;
+    },
+  };
+}
+
+describe("triggers routes", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    for (const model of Object.values(db) as any[]) {
+      for (const fn of Object.values(model) as any[]) {
+        if (typeof fn?.mockReset === "function") fn.mockReset();
+      }
+    }
+  });
+  it("GET /triggers returns items", async () => {
+    db.triggerDefinition.findMany.mockResolvedValueOnce([
+      {
+        id: "t1",
+        name: "Cron schedule",
+        capabilityId: "cap1",
+        config: {},
+        isEnabled: true,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ] as any);
+    const { handlers } = await makeServer();
+    const h = handlers.get("GET /triggers")!;
     let status = 0;
     let body: any = null;
     await h({} as any, {
@@ -25,7 +124,96 @@ describe("admin triggers route", () => {
       sendStream() {},
       sendBuffer() {},
     });
-    expect(status).toBe(501);
-    expect(body?.code).toBe("NOT_IMPLEMENTED");
+    expect(status).toBe(200);
+    expect(Array.isArray(body?.items)).toBe(true);
+    expect(body.items[0]?.id).toBe("t1");
+  });
+
+  it("POST /triggers validates capability and returns 400 when invalid", async () => {
+    const { handlers } = await makeServer();
+    const h = handlers.get("POST /triggers")!;
+    const rc = resCapture();
+    await h({ body: { name: "n1", capabilityId: "capX", config: {} } } as any, rc.res);
+    expect(rc.status).toBe(400);
+    expect(rc.body?.code).toBe("INVALID_CAPABILITY");
+  });
+
+  it("POST /triggers creates trigger and returns 201", async () => {
+    const { handlers } = await makeServer();
+    db.pluginCapability.findUnique.mockResolvedValueOnce({
+      id: "cap1",
+      kind: "TRIGGER",
+      isEnabled: true,
+    } as any);
+    db.triggerDefinition.create.mockResolvedValueOnce({
+      id: "t1",
+      name: "n1",
+      capabilityId: "cap1",
+      config: {},
+      isEnabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as any);
+    const h = handlers.get("POST /triggers")!;
+    const rc = resCapture();
+    await h({ body: { name: "n1", capabilityId: "cap1", config: {} } } as any, rc.res);
+    expect(rc.status).toBe(201);
+    expect(rc.body?.id).toBe("t1");
+    expect(db.triggerDefinition.create).toHaveBeenCalled();
+  });
+
+  it("GET /triggers/:id 404 when missing", async () => {
+    const { handlers } = await makeServer();
+    db.triggerDefinition.findUnique.mockResolvedValueOnce(null as any);
+    const h = handlers.get("GET /triggers/:id")!;
+    const rc = resCapture();
+    await h({ params: { id: "missing" } } as any, rc.res);
+    expect(rc.status).toBe(404);
+  });
+
+  it("POST /triggers/:id updates and returns 204", async () => {
+    const { handlers } = await makeServer();
+    db.triggerDefinition.update.mockResolvedValueOnce({ id: "t1" } as any);
+    const h = handlers.get("POST /triggers/:id")!;
+    const rc = resCapture();
+    await h({ params: { id: "t1" }, body: { isEnabled: false } } as any, rc.res);
+    expect(rc.status).toBe(204);
+    const args = (db.triggerDefinition.update as any).mock.calls[0]?.[0]?.data;
+    expect(args).toHaveProperty("isEnabled", false);
+    expect(args).toHaveProperty("updatedBy");
+  });
+
+  it("DELETE /triggers/:id returns 409 when in use", async () => {
+    const { handlers } = await makeServer();
+    db.triggerEvent.count.mockResolvedValueOnce(1 as any);
+    db.pipelineTrigger.count.mockResolvedValueOnce(0 as any);
+    const h = handlers.get("DELETE /triggers/:id")!;
+    const rc = resCapture();
+    await h({ params: { id: "t1" } } as any, rc.res);
+    expect(rc.status).toBe(409);
+  });
+
+  it("POST /triggers/:id/test-fire returns 202 and calls runner", async () => {
+    const handlers = new Map<string, HttpHandler>();
+    const server = {
+      get: (p: string, h: HttpHandler) => handlers.set(`GET ${p}`, h),
+      post: (p: string, h: HttpHandler) => handlers.set(`POST ${p}`, h),
+      patch: (p: string, h: HttpHandler) => handlers.set(`PATCH ${p}`, h),
+      delete: (p: string, h: HttpHandler) => handlers.set(`DELETE ${p}`, h),
+    } as any;
+    const fire = vi.fn(async () => {});
+    registerTriggerAdminRoutes(server, {
+      fireTriggerOnce: fire,
+      config: {
+        HISTORY_SNAPSHOT_INTERVAL: 20,
+        HISTORY_MAX_CHAIN_DEPTH: 200,
+        SYSTEM_USER_ID: "sys",
+      } as any,
+    });
+    const h = handlers.get("POST /triggers/:id/test-fire")!;
+    const rc = resCapture();
+    await h({ params: { id: "t1" }, body: { context: { a: 1 } } } as any, rc.res);
+    expect(rc.status).toBe(202);
+    expect(fire).toHaveBeenCalledWith("t1", { a: 1 });
   });
 });

--- a/packages/core/src/routes/admin/triggers.ts
+++ b/packages/core/src/routes/admin/triggers.ts
@@ -202,7 +202,6 @@ export function registerTriggerAdminRoutes(
         ...(parsed.data.config !== undefined
           ? { config: parsed.data.config as unknown as Prisma.InputJsonValue }
           : {}),
-        updatedBy: userId,
       };
       const updated = await db.triggerDefinition.update({ where: { id }, data }).catch(() => null);
       if (!updated) {

--- a/packages/core/src/routes/admin/triggers.ts
+++ b/packages/core/src/routes/admin/triggers.ts
@@ -1,9 +1,279 @@
-import type { HttpServer } from "../../http/http-server";
+import { z } from "zod";
+import type { HttpServer } from "../../http/http-server.js";
+import { getDb } from "../../db/db.js";
+import type { Prisma, ChangeKind } from "@latchflow/db";
+import { requireAdminOrApiToken } from "../../middleware/require-admin-or-api-token.js";
+import { SCOPES } from "../../auth/scopes.js";
+import type { RouteSignature } from "../../authz/policy.js";
+import type { AppConfig } from "../../config/config.js";
+import { appendChangeLog } from "../../history/changelog.js";
 
-export function registerTriggerAdminRoutes(server: HttpServer) {
-  server.get("/admin/triggers", (_req, res) => {
-    res
-      .status(501)
-      .json({ status: "error", code: "NOT_IMPLEMENTED", message: "Triggers list not implemented" });
+type FireFn = (triggerDefinitionId: string, context?: Record<string, unknown>) => Promise<void>;
+
+export function registerTriggerAdminRoutes(
+  server: HttpServer,
+  deps?: { fireTriggerOnce?: FireFn; config?: AppConfig },
+) {
+  const db = getDb();
+  const defaultHistoryCfg: Pick<
+    AppConfig,
+    "HISTORY_SNAPSHOT_INTERVAL" | "HISTORY_MAX_CHAIN_DEPTH"
+  > = { HISTORY_SNAPSHOT_INTERVAL: 20, HISTORY_MAX_CHAIN_DEPTH: 200 };
+  const historyCfg: Pick<AppConfig, "HISTORY_SNAPSHOT_INTERVAL" | "HISTORY_MAX_CHAIN_DEPTH"> =
+    deps?.config ?? defaultHistoryCfg;
+  const systemUserId = deps?.config?.SYSTEM_USER_ID ?? "system";
+
+  const toTriggerDto = (t: {
+    id: string;
+    name: string;
+    capabilityId: string;
+    config: unknown;
+    isEnabled: boolean;
+    createdAt: Date | string;
+    updatedAt: Date | string;
+  }) => ({
+    id: t.id,
+    name: t.name,
+    capabilityId: t.capabilityId,
+    config: t.config as Record<string, unknown>,
+    isEnabled: t.isEnabled,
+    createdAt: typeof t.createdAt === "string" ? t.createdAt : t.createdAt.toISOString(),
+    updatedAt: typeof t.updatedAt === "string" ? t.updatedAt : t.updatedAt.toISOString(),
   });
+
+  // GET /triggers — list
+  server.get(
+    "/triggers",
+    requireAdminOrApiToken({
+      policySignature: "GET /triggers" as RouteSignature,
+      scopes: [SCOPES.TRIGGERS_READ],
+    })(async (req, res) => {
+      try {
+        const Q = z.object({
+          limit: z.coerce.number().int().min(1).max(200).optional(),
+          cursor: z.string().optional(),
+          q: z.string().optional(),
+          pluginId: z.string().optional(),
+          capabilityKey: z.string().optional(),
+          enabled: z.coerce.boolean().optional(),
+          updatedSince: z.coerce.date().optional(),
+        });
+        const qp = Q.safeParse(req.query ?? {});
+        const q = qp.success ? qp.data : {};
+        const where: Prisma.TriggerDefinitionWhereInput = {};
+        if (q.q) where.name = { contains: q.q, mode: "insensitive" };
+        if (typeof q.enabled === "boolean") where.isEnabled = q.enabled;
+        if (q.updatedSince) where.updatedAt = { gte: q.updatedSince };
+        if (q.pluginId || q.capabilityKey) {
+          const capWhere: Prisma.PluginCapabilityWhereInput = {};
+          if (q.pluginId) capWhere.pluginId = q.pluginId;
+          if (q.capabilityKey)
+            capWhere.key = {
+              contains: q.capabilityKey,
+              mode: "insensitive",
+            } as unknown as Prisma.StringFilter;
+          // Relational filter: to-one relation uses `is`
+          (
+            where as Prisma.TriggerDefinitionWhereInput & {
+              capability?: { is?: Prisma.PluginCapabilityWhereInput | null };
+            }
+          ).capability = { is: capWhere };
+        }
+        const rows = await db.triggerDefinition.findMany({
+          where,
+          orderBy: { id: "desc" },
+          take: q.limit ?? 50,
+          ...(q.cursor ? { cursor: { id: q.cursor }, skip: 1 } : {}),
+        });
+        const items = rows.map(toTriggerDto);
+        const nextCursor = rows.length === (q.limit ?? 50) ? rows[rows.length - 1]?.id : undefined;
+        res.status(200).json({ items, nextCursor });
+      } catch (e) {
+        const err = e as Error & { status?: number };
+        res
+          .status(err.status ?? 401)
+          .json({ status: "error", code: "UNAUTHORIZED", message: err.message });
+      }
+    }),
+  );
+
+  // POST /triggers — create
+  server.post(
+    "/triggers",
+    requireAdminOrApiToken({
+      policySignature: "POST /triggers" as RouteSignature,
+      scopes: [SCOPES.TRIGGERS_WRITE],
+    })(async (req, res) => {
+      try {
+        const Body = z.object({
+          name: z.string().min(1),
+          capabilityId: z.string().min(1),
+          config: z.unknown(),
+        });
+        const parsed = Body.safeParse(req.body ?? {});
+        if (!parsed.success) {
+          res.status(400).json({ status: "error", code: "BAD_REQUEST", message: "Invalid body" });
+          return;
+        }
+        const { name, capabilityId, config } = parsed.data;
+        // Validate capability exists and is a TRIGGER
+        const cap = await db.pluginCapability.findUnique({ where: { id: capabilityId } });
+        if (!cap || cap.kind !== "TRIGGER" || cap.isEnabled === false) {
+          res.status(400).json({ status: "error", code: "INVALID_CAPABILITY" });
+          return;
+        }
+        const userId = ((req as unknown as { user?: { id?: string } }).user?.id ??
+          systemUserId) as string;
+        const created = await db.triggerDefinition.create({
+          data: {
+            name,
+            capabilityId,
+            config: config as unknown as Prisma.InputJsonValue,
+            createdBy: userId,
+          },
+        });
+        // ChangeLog
+        await appendChangeLog(
+          db,
+          historyCfg,
+          "TRIGGER_DEFINITION",
+          created.id,
+          { actorType: "USER", actorUserId: userId },
+          { changeKind: "UPDATE_PARENT" as ChangeKind },
+        );
+        res.status(201).json(toTriggerDto(created));
+      } catch (e) {
+        const err = e as Error & { status?: number };
+        res
+          .status(err.status ?? 401)
+          .json({ status: "error", code: "UNAUTHORIZED", message: err.message });
+      }
+    }),
+  );
+
+  // GET /triggers/:id — get by id
+  server.get(
+    "/triggers/:id",
+    requireAdminOrApiToken({
+      policySignature: "GET /triggers/:id" as RouteSignature,
+      scopes: [SCOPES.TRIGGERS_READ],
+    })(async (req, res) => {
+      const id = (req.params as Record<string, string> | undefined)?.id;
+      if (!id) {
+        res.status(400).json({ status: "error", code: "BAD_REQUEST" });
+        return;
+      }
+      const row = await db.triggerDefinition.findUnique({ where: { id } });
+      if (!row) {
+        res.status(404).json({ status: "error", code: "NOT_FOUND" });
+        return;
+      }
+      res.status(200).json(toTriggerDto(row));
+    }),
+  );
+
+  // POST /triggers/:id — update (HTTP layer uses POST; OpenAPI exposes PATCH + alias)
+  server.post(
+    "/triggers/:id",
+    requireAdminOrApiToken({
+      policySignature: "PATCH /triggers/:id" as RouteSignature,
+      scopes: [SCOPES.TRIGGERS_WRITE],
+    })(async (req, res) => {
+      const id = (req.params as Record<string, string> | undefined)?.id;
+      if (!id) {
+        res.status(400).json({ status: "error", code: "BAD_REQUEST" });
+        return;
+      }
+      const Body = z.object({
+        name: z.string().min(1).optional(),
+        isEnabled: z.boolean().optional(),
+        config: z.unknown().optional(),
+      });
+      const parsed = Body.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        res.status(400).json({ status: "error", code: "BAD_REQUEST" });
+        return;
+      }
+      const userId = ((req as unknown as { user?: { id?: string } }).user?.id ??
+        systemUserId) as string;
+      const data: Prisma.TriggerDefinitionUpdateInput = {
+        ...(parsed.data.name ? { name: parsed.data.name } : {}),
+        ...(typeof parsed.data.isEnabled === "boolean" ? { isEnabled: parsed.data.isEnabled } : {}),
+        ...(parsed.data.config !== undefined
+          ? { config: parsed.data.config as unknown as Prisma.InputJsonValue }
+          : {}),
+        updatedBy: userId,
+      };
+      const updated = await db.triggerDefinition.update({ where: { id }, data }).catch(() => null);
+      if (!updated) {
+        res.status(404).json({ status: "error", code: "NOT_FOUND" });
+        return;
+      }
+      await appendChangeLog(
+        db,
+        historyCfg,
+        "TRIGGER_DEFINITION",
+        id,
+        { actorType: "USER", actorUserId: userId },
+        { changeKind: "UPDATE_PARENT" as ChangeKind },
+      );
+      res.status(204).json({});
+    }),
+  );
+
+  // DELETE /triggers/:id — delete (409 when in use)
+  server.delete(
+    "/triggers/:id",
+    requireAdminOrApiToken({
+      policySignature: "DELETE /triggers/:id" as RouteSignature,
+      scopes: [SCOPES.TRIGGERS_WRITE],
+    })(async (req, res) => {
+      const id = (req.params as Record<string, string> | undefined)?.id;
+      if (!id) {
+        res.status(400).json({ status: "error", code: "BAD_REQUEST" });
+        return;
+      }
+      const [evtCount, linkCount] = await Promise.all([
+        db.triggerEvent.count({ where: { triggerDefinitionId: id } }),
+        db.pipelineTrigger.count({ where: { triggerId: id } }),
+      ]);
+      if (evtCount > 0 || linkCount > 0) {
+        res.status(409).json({ status: "error", code: "IN_USE" });
+        return;
+      }
+      const ok = await db.triggerDefinition
+        .delete({ where: { id } })
+        .then(() => true)
+        .catch(() => false);
+      if (!ok) {
+        res.status(404).json({ status: "error", code: "NOT_FOUND" });
+        return;
+      }
+      res.status(204).json({});
+    }),
+  );
+
+  // POST /triggers/:id/test-fire — optional utility
+  server.post(
+    "/triggers/:id/test-fire",
+    requireAdminOrApiToken({
+      policySignature: "POST /triggers/:id/test-fire" as RouteSignature,
+      scopes: [SCOPES.TRIGGERS_WRITE],
+    })(async (req, res) => {
+      const id = (req.params as Record<string, string> | undefined)?.id;
+      if (!id) {
+        res.status(400).json({ status: "error", code: "BAD_REQUEST" });
+        return;
+      }
+      const Body = z.object({ context: z.record(z.any()).optional() });
+      const parsed = Body.safeParse(req.body ?? {});
+      const context = parsed.success && parsed.data.context ? parsed.data.context : {};
+      if (!deps?.fireTriggerOnce) {
+        res.status(503).json({ status: "error", code: "TRIGGER_RUNNER_UNAVAILABLE" });
+        return;
+      }
+      await deps.fireTriggerOnce(id, context);
+      res.status(202).json({});
+    }),
+  );
 }

--- a/packages/core/tests/e2e/triggers.e2e.test.ts
+++ b/packages/core/tests/e2e/triggers.e2e.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import type { HttpHandler, HttpServer, ResponseLike } from "../../src/http/http-server.js";
+import { getEnv } from "@tests/helpers/containers";
+
+// Bypass auth; attach synthetic admin user id on requests
+let ADMIN_ID = "e2e-admin";
+vi.mock("../../src/middleware/require-admin-or-api-token.js", () => ({
+  requireAdminOrApiToken: (_opts: any) => (h: HttpHandler) => async (req: any, res: any) => {
+    req.user = { id: ADMIN_ID };
+    return h(req, res);
+  },
+}));
+
+function makeServer() {
+  const handlers = new Map<string, HttpHandler>();
+  const server: HttpServer = {
+    get: (p, h) => {
+      handlers.set(`GET ${p}`, h);
+      return undefined as any;
+    },
+    post: (p, h) => {
+      handlers.set(`POST ${p}`, h);
+      return undefined as any;
+    },
+    put: (p, h) => {
+      handlers.set(`PUT ${p}`, h);
+      return undefined as any;
+    },
+    delete: (p, h) => {
+      handlers.set(`DELETE ${p}`, h);
+      return undefined as any;
+    },
+    use: () => undefined as any,
+    listen: async () => undefined as any,
+  } as unknown as HttpServer;
+  return { handlers, server };
+}
+
+function resCapture() {
+  let status = 0;
+  let body: any = null;
+  const headers: Record<string, string | string[]> = {};
+  const res: ResponseLike = {
+    status(c: number) {
+      status = c;
+      return this;
+    },
+    json(p: any) {
+      body = p;
+    },
+    header(name: string, value: any) {
+      headers[name] = value;
+      return this;
+    },
+    redirect() {},
+    sendStream() {},
+    sendBuffer() {},
+  };
+  return {
+    res,
+    get status() {
+      return status;
+    },
+    get body() {
+      return body;
+    },
+    headers,
+  };
+}
+
+async function seedPluginWithTriggerAndAction() {
+  const { prisma } = await import("@latchflow/db");
+  const p = await prisma.plugin.create({ data: { name: `e2e_triggers_${Date.now()}` } });
+  const trig = await prisma.pluginCapability.create({
+    data: {
+      pluginId: p.id,
+      kind: "TRIGGER",
+      key: "cron",
+      displayName: "Cron Schedule",
+      jsonSchema: { type: "object" },
+      isEnabled: true,
+    },
+  });
+  const act = await prisma.pluginCapability.create({
+    data: {
+      pluginId: p.id,
+      kind: "ACTION",
+      key: "email",
+      displayName: "Email Notify",
+      jsonSchema: { type: "object" },
+      isEnabled: true,
+    },
+  });
+  return { plugin: p, trigCap: trig, actCap: act };
+}
+
+describe("E2E: Triggers endpoints", () => {
+  beforeAll(() => {
+    // Ensure containers env is initialized (DATABASE_URL set by e2e setup)
+    expect(getEnv().postgres.url).toBeTruthy();
+  });
+
+  it("create → update → link pipeline → test-fire → list → delete behavior", async () => {
+    const { handlers, server } = makeServer();
+    const { registerTriggerAdminRoutes } = await import("../../src/routes/admin/triggers.js");
+    const { startTriggerRunner } = await import("../../src/runtime/trigger-runner.js");
+
+    const { prisma } = await import("@latchflow/db");
+    const admin = await prisma.user.upsert({
+      where: { email: "e2e.triggers@example.com" },
+      update: {},
+      create: { email: "e2e.triggers@example.com", role: "ADMIN" as any },
+    });
+    ADMIN_ID = admin.id;
+
+    const seed = await seedPluginWithTriggerAndAction();
+
+    // Runner: onFire immediately creates ActionInvocation rows (simulate queue consumer)
+    const runner = await startTriggerRunner({
+      onFire: async (msg: {
+        actionDefinitionId: string;
+        triggerEventId: string;
+        context?: any;
+      }) => {
+        await prisma.actionInvocation.create({
+          data: {
+            actionDefinitionId: msg.actionDefinitionId,
+            triggerEventId: msg.triggerEventId,
+            status: "PENDING",
+          },
+        });
+      },
+    });
+
+    registerTriggerAdminRoutes(server, {
+      fireTriggerOnce: runner.fireTriggerOnce,
+      config: {
+        HISTORY_SNAPSHOT_INTERVAL: 20,
+        HISTORY_MAX_CHAIN_DEPTH: 200,
+        SYSTEM_USER_ID: ADMIN_ID,
+      } as any,
+    });
+
+    // Create trigger
+    const hCreate = handlers.get("POST /triggers")!;
+    const rcCreate = resCapture();
+    await hCreate(
+      {
+        headers: {},
+        body: {
+          name: "Cron Trigger",
+          capabilityId: seed.trigCap.id,
+          config: { schedule: "* * * * *" },
+        },
+      } as any,
+      rcCreate.res,
+    );
+    expect(rcCreate.status).toBe(201);
+    const triggerId = rcCreate.body.id as string;
+
+    // Update: disable
+    const hUpdate = handlers.get("POST /triggers/:id")!;
+    const rcUpdate = resCapture();
+    await hUpdate(
+      { headers: {}, params: { id: triggerId }, body: { isEnabled: false } } as any,
+      rcUpdate.res,
+    );
+    expect(rcUpdate.status).toBe(204);
+    const updated = await prisma.triggerDefinition.findUnique({ where: { id: triggerId } });
+    expect(updated?.isEnabled).toBe(false);
+
+    // Create action and pipeline linking to the trigger
+    const action = await prisma.actionDefinition.create({
+      data: {
+        name: "Email",
+        capabilityId: seed.actCap.id,
+        config: {},
+        createdBy: ADMIN_ID,
+      },
+    });
+    const pipeline = await prisma.pipeline.create({
+      data: { name: "P1", isEnabled: true, createdBy: ADMIN_ID },
+    });
+    await prisma.pipelineStep.create({
+      data: {
+        pipelineId: pipeline.id,
+        actionId: action.id,
+        sortOrder: 1,
+        isEnabled: true,
+        createdBy: ADMIN_ID,
+      },
+    });
+    await prisma.pipelineTrigger.create({
+      data: {
+        pipelineId: pipeline.id,
+        triggerId: triggerId,
+        sortOrder: 1,
+        isEnabled: true,
+        createdBy: ADMIN_ID,
+      },
+    });
+
+    // Re-enable trigger for firing
+    const rcUpdate2 = resCapture();
+    await hUpdate(
+      { headers: {}, params: { id: triggerId }, body: { isEnabled: true } } as any,
+      rcUpdate2.res,
+    );
+    expect(rcUpdate2.status).toBe(204);
+
+    // Test-fire
+    const hFire = handlers.get("POST /triggers/:id/test-fire")!;
+    const rcFire = resCapture();
+    await hFire(
+      { headers: {}, params: { id: triggerId }, body: { context: { foo: "bar" } } } as any,
+      rcFire.res,
+    );
+    expect(rcFire.status).toBe(202);
+
+    // Verify TriggerEvent and ActionInvocation persisted
+    const evts = await prisma.triggerEvent.findMany({ where: { triggerDefinitionId: triggerId } });
+    expect(evts.length).toBeGreaterThanOrEqual(1);
+    const invs = await prisma.actionInvocation.findMany({ where: { triggerEventId: evts[0].id } });
+    expect(invs.length).toBeGreaterThanOrEqual(1);
+
+    // List with filters
+    const hList = handlers.get("GET /triggers")!;
+    const rcList = resCapture();
+    await hList(
+      { headers: {}, query: { pluginId: seed.plugin.id, capabilityKey: "cron", q: "Cron" } } as any,
+      rcList.res,
+    );
+    expect(rcList.status).toBe(200);
+    expect(Array.isArray(rcList.body?.items)).toBe(true);
+    expect(rcList.body.items.some((t: any) => t.id === triggerId)).toBe(true);
+
+    // Delete should now fail with 409 due to usage/linkage
+    const hDel = handlers.get("DELETE /triggers/:id")!;
+    const rcDelFail = resCapture();
+    await hDel({ headers: {}, params: { id: triggerId } } as any, rcDelFail.res);
+    expect(rcDelFail.status).toBe(409);
+
+    // Create an unused trigger and delete it
+    const rcCreate2 = resCapture();
+    await hCreate(
+      {
+        headers: {},
+        body: { name: "Temp Trigger", capabilityId: seed.trigCap.id, config: {} },
+      } as any,
+      rcCreate2.res,
+    );
+    const tempId = rcCreate2.body.id as string;
+    const rcDelOk = resCapture();
+    await hDel({ headers: {}, params: { id: tempId } } as any, rcDelOk.res);
+    expect(rcDelOk.status).toBe(204);
+    const missing = await prisma.triggerDefinition.findUnique({ where: { id: tempId } });
+    expect(missing).toBeNull();
+  });
+});

--- a/packages/core/tests/integration/triggers.integration.test.ts
+++ b/packages/core/tests/integration/triggers.integration.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { HttpHandler } from "../../src/http/http-server.js";
+
+// Prisma-like mock
+const db = {
+  triggerDefinition: {
+    findMany: vi.fn(async () => []),
+    findUnique: vi.fn(async () => null),
+    create: vi.fn(async (..._args: any[]) => ({})),
+    update: vi.fn(async (..._args: any[]) => ({})),
+    delete: vi.fn(async (..._args: any[]) => ({})),
+  },
+  pluginCapability: {
+    findUnique: vi.fn(async () => null),
+  },
+  triggerEvent: { count: vi.fn(async () => 0) },
+  pipelineTrigger: { count: vi.fn(async () => 0) },
+};
+
+vi.mock("../../src/db/db.js", () => ({ getDb: () => db }));
+
+// Permission path relies on requireSession; allow ADMIN through
+vi.mock("../../src/middleware/require-session.js", () => ({
+  requireSession: vi.fn(async () => ({ user: { id: "u1", role: "ADMIN" } })),
+}));
+
+// Stub ChangeLog appends
+vi.mock("../../src/history/changelog.js", () => ({
+  appendChangeLog: vi.fn(async () => ({ id: "cl1", version: 1 })),
+}));
+
+function makeServer() {
+  const handlers = new Map<string, HttpHandler>();
+  const server = {
+    get: (p: string, h: HttpHandler) => handlers.set(`GET ${p}`, h),
+    post: (p: string, h: HttpHandler) => handlers.set(`POST ${p}`, h),
+    delete: (p: string, h: HttpHandler) => handlers.set(`DELETE ${p}`, h),
+  } as any;
+  return { handlers, server };
+}
+
+function resCapture() {
+  let status = 0;
+  let body: any = null;
+  const headers: Record<string, string | string[]> = {};
+  const res = {
+    status(c: number) {
+      status = c;
+      return this as any;
+    },
+    json(p: any) {
+      body = p;
+    },
+    header(name: string, value: any) {
+      headers[name] = value;
+      return this as any;
+    },
+    redirect() {},
+    sendStream() {},
+    sendBuffer() {},
+  } as any;
+  return {
+    res,
+    get status() {
+      return status;
+    },
+    get body() {
+      return body;
+    },
+    get headers() {
+      return headers;
+    },
+  };
+}
+
+describe("triggers admin routes (integration)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    for (const model of Object.values(db) as any[]) {
+      for (const fn of Object.values(model) as any[]) {
+        if (typeof fn?.mockReset === "function") fn.mockReset();
+      }
+    }
+  });
+
+  it("create → enable toggle → list filters → delete", async () => {
+    const { handlers, server } = makeServer();
+    const { registerTriggerAdminRoutes } = await import("../../src/routes/admin/triggers.js");
+    const fire = vi.fn(async () => {});
+    registerTriggerAdminRoutes(server, {
+      fireTriggerOnce: fire,
+      config: {
+        HISTORY_SNAPSHOT_INTERVAL: 20,
+        HISTORY_MAX_CHAIN_DEPTH: 200,
+        SYSTEM_USER_ID: "sys",
+      } as any,
+    });
+
+    // Create
+    db.pluginCapability.findUnique.mockResolvedValueOnce({
+      id: "cap1",
+      kind: "TRIGGER",
+      isEnabled: true,
+    } as any);
+    db.triggerDefinition.create.mockResolvedValueOnce({
+      id: "t1",
+      name: "Cron",
+      capabilityId: "cap1",
+      config: {},
+      isEnabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as any);
+    const rcCreate = resCapture();
+    await handlers.get("POST /triggers")!(
+      { body: { name: "Cron", capabilityId: "cap1", config: {} } } as any,
+      rcCreate.res,
+    );
+    expect(rcCreate.status).toBe(201);
+
+    // Enable toggle (disable now)
+    db.triggerDefinition.update.mockResolvedValueOnce({ id: "t1" } as any);
+    const rcUpdate = resCapture();
+    await handlers.get("POST /triggers/:id")!(
+      { params: { id: "t1" }, body: { isEnabled: false } } as any,
+      rcUpdate.res,
+    );
+    expect(rcUpdate.status).toBe(204);
+
+    // List with filter
+    db.triggerDefinition.findMany.mockResolvedValueOnce([] as any);
+    const rcList = resCapture();
+    await handlers.get("GET /triggers")!(
+      { query: { pluginId: "p1", capabilityKey: "cron", q: "cr" } } as any,
+      rcList.res,
+    );
+    const args = (db.triggerDefinition.findMany as any).mock.calls[0]?.[0];
+    const cap = args?.where?.capability;
+    const pluginId = cap?.pluginId ?? cap?.is?.pluginId;
+    const keyContains = cap?.key?.contains ?? cap?.is?.key?.contains;
+    expect(pluginId).toBe("p1");
+    expect(keyContains).toBe("cron");
+    expect(args?.where?.name?.contains).toBe("cr");
+
+    // Delete
+    db.triggerEvent.count.mockResolvedValueOnce(0 as any);
+    db.pipelineTrigger.count.mockResolvedValueOnce(0 as any);
+    db.triggerDefinition.delete.mockResolvedValueOnce({} as any);
+    const rcDelete = resCapture();
+    await handlers.get("DELETE /triggers/:id")!({ params: { id: "t1" } } as any, rcDelete.res);
+    expect(rcDelete.status).toBe(204);
+  });
+});


### PR DESCRIPTION
## **Summary**

Implement admin trigger endpoints (route file lives at `packages/core/src/routes/admin/triggers.ts`) that expose API paths under `/triggers`. Provide pagination and filters, strict validation (capability exists), enable/disable toggles, AuthZ, OpenAPI updates, and tests. Actual runtime firing is handled by the trigger runner; this PR focuses on CRUD and an optional `test-fire` endpoint.

## **Scope**

- Trigger definitions CRUD: list, get, create, update, delete.
- State: enable/disable (`isEnabled`) on a trigger definition.
- Capability validation: ensure referenced capability exists and is enabled in the DB (`PluginCapability.kind = TRIGGER`).
- Filters on list: `pluginId`, `capabilityKey`, `enabled`, `q` (name contains, case‑insensitive), `updatedSince` (ISO), plus `limit`/`cursor`.
- AuthZ/scopes: enforce with `requireAdminOrApiToken`; use `TRIGGERS_READ`/`TRIGGERS_WRITE` scopes; add policy entries.
- DTOs: `TriggerDefinition` mapper (BigInt → number as needed; dates → ISO; stable response shape).
- OpenAPI: update `/triggers*` paths and schemas; remove version endpoints; add parameters and errors.
- Optional: `POST /triggers/{id}/test-fire` that creates a `TriggerEvent` and enqueues actions via the runner’s fire function; returns 202.
- Tests: unit route tests with Prisma mock; integration flow for create → enable → list → delete; add targeted E2E tests.

## **To‑Do**

- [x] AuthZ & Scopes
  - [x] Add policy entries for: `GET /triggers`, `POST /triggers`, `GET /triggers/:id`, `PATCH /triggers/:id`, `DELETE /triggers/:id`, and optional `POST /triggers/:id/test-fire` (resource: `trigger_def`).
  - [x] Guard all routes with `requireAdminOrApiToken({ scopes: [SCOPES.TRIGGERS_READ|TRIGGERS_WRITE] })` (read vs write).
- [x] DTOs
  - [x] `toTriggerDto(td: { id, name, capabilityId, config, isEnabled, createdAt, updatedAt })` → ISO dates; stable output.
- [x] Routes: Triggers (file: `routes/admin/triggers.ts`, API path prefix: `/triggers`)
  - [x] `GET /triggers`
    - [x] Query: `limit`, `cursor`, `q` (name contains), `pluginId`, `capabilityKey`, `enabled`, `updatedSince` (ISO)
    - [x] Response: `{ items: Trigger[], nextCursor? }`
  - [x] `POST /triggers` (body: `{ name, capabilityId, config }`)
    - [x] Validate that `capabilityId` exists in DB and `kind = TRIGGER` and `isEnabled = true`; 400 otherwise.
  - [x] `GET /triggers/{id}`
  - [x] `PATCH /triggers/{id}` (body: `{ name?, isEnabled?, config? }`) [HTTP uses POST alias]
  - [x] `DELETE /triggers/{id}`
    - [x] Reject with 409 when referenced by `PipelineTrigger` or has `TriggerEvent` history; prefer disabling when in use.
- [x] Optional utility
  - [x] `POST /triggers/{id}/test-fire` → creates a `TriggerEvent` and enqueues actions using an injected `fireTriggerOnce`; returns 202.
- [x] Validation
  - [x] Use zod schemas and `http/validate.ts` helpers where ergonomic; strict types in handlers.
- [x] OpenAPI
  - [x] Update `packages/core/openapi/paths/triggers.yaml` with the CRUD and `test-fire` endpoints, parameters, pagination, and error responses (400/401/403/404/409).
  - [x] Remove `/triggers/{id}/versions*` from the spec.
  - [x] Fix `components/schemas/TriggerDefinition.yaml` required fields to match the DB model (remove `ownerId`; include `isEnabled`, `createdAt`, `updatedAt`).
- [x] Tests
  - [x] Unit: per-route happy paths, validation failures, 404 for missing ids, 409 on delete‑in‑use.
  - [x] Integration (`packages/core/tests/integration/triggers.integration.test.ts`): create → enable toggle → list with filters → delete (or disable when in use).
  - [x] E2E (`packages/core/tests/e2e/**/*.e2e.test.ts`): minimal flow using Testcontainers to assert `POST /triggers` + `.../test-fire` creates a `TriggerEvent` and a subsequent `ActionInvocation`; update + list filters + delete behavior.
- [x] Docs
  - [x] README: brief admin trigger lifecycle (create, enable/disable, test‑fire).
  - [x] AGENTS.md: note trigger AuthZ resources/actions and DB‑backed capability validation rule.

## **Data & Rules**

- Model: `TriggerDefinition` (Prisma) holds current `config`; no explicit version model in this PR. Historical views can rely on ChangeLog in future work.
- Capability validation: validate against DB `PluginCapability` (`kind = TRIGGER`, `isEnabled = true`). The plugin runtime populates the DB on startup; route‑level checks do not need the in‑memory registry.
- Delete semantics: prefer disabling (`isEnabled = false`). `DELETE` should return 409 when the trigger is referenced by pipelines or has events.
- Atomicity: treat updates and delete checks as single transactions where needed.
- Auditing: append ChangeLog entries for `TRIGGER_DEFINITION` on create and update (using canonical serializer with redaction). No version endpoints; history is via ChangeLog materialization only.

## **Pagination & Filters**

- `GET /triggers`: cursor + limit; filters: `q` (name contains), `pluginId`, `capabilityKey`, `enabled`, `updatedSince`.

## **DoD**

- [x] All `/triggers*` routes implemented at API path `/triggers` (route code in `routes/admin/triggers.ts`) and gated with `TRIGGERS_*` scopes.
- [x] DTOs map types safely; stable response shapes.
- [x] OpenAPI updated (versions removed; `test-fire` added if implemented) and validates.
- [x] Unit/integration tests pass locally; E2E tests run with local containers and memory queue.
- [x] Error handling: consistent 400/401/403/404/409 where applicable.
- [x] Docs updated with usage and testing notes.
- [x] ChangeLog entries are written on create/update and can be materialized.

---

## **Implementation Notes: Trigger Firing (`test-fire`)**

- Current runner: `startTriggerRunner({ onFire })` inserts a `TriggerEvent` then looks up attached pipelines and enqueues actions (`queue.enqueueAction`) via the provided callback. `startActionConsumer` handles the queue and writes `ActionInvocation` rows.
- Route wiring options:
  1) Inject `fireTriggerOnce` into route registration from `index.ts`, mirroring how storage is injected elsewhere. `POST /triggers/{id}/test-fire` calls it and returns 202.
  2) Inject the queue and re‑implement the minimal sequence inside the route (create `TriggerEvent`, resolve pipelines, enqueue actions). Prefer (1) to keep logic centralized.
- This plan assumes (1): expose the runner’s `fireTriggerOnce` to the route via dependency injection.
